### PR TITLE
Issue8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Qt5Widgets)
 find_package(Qt5DBus)
 
 #main GUI application
-add_executable(digcross src/main.cpp src/mainwindow.cpp src/cardreader.cpp src/daemon_client.cpp)
+add_executable(digcross src/main.cpp src/mainwindow.cpp src/cardreader.cpp src/daemon_client.cpp src/shoppinglist.cpp)
 target_link_libraries(digcross Qt5::Widgets Qt5::DBus)
 
 #transaction daemon

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -23,7 +23,8 @@ MainWindow::MainWindow(QWidget *parent)
 	ShoppingListWidget *shoppingListWidget = new ShoppingListWidget(list);
 	layout->addWidget(shoppingListWidget);
 
-	//FIXME: Populate with some example data.
+	//Populate with some example data.
+	//Menu class will have to connect to ShoppingList::newItem().
 	list->newItem("Brus", 15, 2);
 	list->newItem("Godterisopp", 2, 35);
 	list->newItem("Kvikklunsj", 10, 1);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4,11 +4,11 @@
 #include <QGridLayout>
 #include <QLabel>
 
+#include "shoppinglist.h"
+
 MainWindow::MainWindow(QWidget *parent)
 {
 	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(new QLabel("ARK kryssesystem. Bipp et kort:"));
-
 	QLabel *testLabel = new QLabel;
 	layout->addWidget(testLabel);
 
@@ -16,4 +16,16 @@ MainWindow::MainWindow(QWidget *parent)
 	CardReader *cardReader = new CardReader(this);
 	installEventFilter(cardReader);
 	connect(cardReader, SIGNAL(newCardNumber(QString)), testLabel, SLOT(setText(QString)));
+
+	//shoppinglist and associated view
+	ShoppingList *list = new ShoppingList(this);
+
+	ShoppingListWidget *shoppingListWidget = new ShoppingListWidget(list);
+	layout->addWidget(shoppingListWidget);
+
+	//FIXME: Populate with some example data.
+	list->newItem("Brus", 15, 2);
+	list->newItem("Godterisopp", 2, 35);
+	list->newItem("Kvikklunsj", 10, 1);
+	list->newItem("Ragni spesial", 788.5, 3);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,10 +1,14 @@
 #include <QWidget>
 
+class ShoppingList;
+
 /**
- * Mainwindow container widget opened when starting digikryss.
+ * Mainwindow container widget opened when starting digcross.
  **/
 class MainWindow : public QWidget {
 	Q_OBJECT
 	public:
 		MainWindow(QWidget *parent = NULL);
+	private:
+		ShoppingList *shoppingList;
 };

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -2,6 +2,15 @@
 #include <iostream>
 #include <QHash>
 
+///Number of properties associated with each shopping list item (price, name, amount)
+const int NUM_SHOPPINGLIST_PROPERTIES = 3;
+///Column index for name in shopping list model
+#define ITEM_NAME_COL 0
+///Column index for price in shopping list model
+#define ITEM_PRICE_COL 1
+///Column index for amount in shopping list model
+#define ITEM_AMOUNT_COL 2
+
 ShoppingList::ShoppingList(QObject *parent) : QAbstractTableModel(parent)
 {
 }

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -1,6 +1,4 @@
 #include "shoppinglist.h"
-#include <iostream>
-#include <QHash>
 
 ///Number of properties associated with each shopping list item (price, name, amount)
 const int NUM_SHOPPINGLIST_PROPERTIES = 3;

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -251,6 +251,7 @@ void ShoppingListWidget::updateDisplayPrice()
 void ShoppingListWidget::deleteShoppingListRow(const QModelIndex &index)
 {
 	if (index.isValid() && (index.column() == ITEM_DELETEBUTTON_COL)) {
+		//signal came from clicking on the delete button-cell, so can safely delete the row
 		shoppingList->deleteItem(index);
 	}
 }

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -1,14 +1,5 @@
 #include "shoppinglist.h"
 
-///Number of properties associated with each shopping list item (price, name, amount)
-const int NUM_SHOPPINGLIST_PROPERTIES = 3;
-///Column index for name in shopping list model
-#define ITEM_NAME_COL 1
-///Column index for price in shopping list model
-#define ITEM_PRICE_COL 2
-///Column index for amount in shopping list model
-#define ITEM_AMOUNT_COL 0
-
 ShoppingList::ShoppingList(QObject *parent) : QAbstractTableModel(parent)
 {
 }
@@ -157,6 +148,22 @@ Qt::ItemFlags ShoppingList::flags(const QModelIndex &index) const
 	}
 }
 
+QVariant ShoppingList::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	if ((orientation == Qt::Horizontal) && (role == Qt::DisplayRole)) {
+		switch (section) {
+			case ITEM_NAME_COL:
+				return QVariant(tr("Name"));
+			case ITEM_PRICE_COL:
+				return QVariant(tr("Price"));
+			case ITEM_AMOUNT_COL:
+				return QVariant(tr("Amount"));
+		}
+	}
+
+	return QAbstractTableModel::headerData(section, orientation, role);
+}
+
 /**
  * QAbstractTableModel edit functions.
  **/
@@ -185,7 +192,8 @@ ShoppingListItemDelegate::ShoppingListItemDelegate(QObject *parent) : QStyledIte
 void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE
 {
 	if (index.column() == ITEM_AMOUNT_COL) {
-		painter->drawText(option.rect, option.displayAlignment, index.data().toString());
+		painter->drawText(option.rect, option.displayAlignment, index.data().toString() + " x ");
+	} else if (index.column() == ITEM_PRICE_COL) {
 	} else {
 		QStyledItemDelegate::paint(painter, option, index);
 	}
@@ -195,8 +203,8 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 {
 	//view for displaying shopping list
 	QTableView *listView = new QTableView;
-	listView->horizontalHeader()->hide();
 	listView->verticalHeader()->hide();
+	listView->setAlternatingRowColors(true);
 	listView->setGridStyle(Qt::NoPen);
 	listView->setModel(list);
 
@@ -208,5 +216,5 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	layout->addWidget(new QLabel(tr("Sum: ")), 0, 0);
 	QLabel *currSum = new QLabel("0");
 	layout->addWidget(currSum, 0, 1);
-	layout->addWidget(listView);
+	layout->addWidget(listView, 1, 0, 1, 2);
 }

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -70,16 +70,44 @@ int ShoppingList::columnCount(const QModelIndex &parent) const
 
 QVariant ShoppingList::data(const QModelIndex &index, int role) const
 {
-	ShoppingListData::const_iterator item = getItem(index);
-	int column = index.column();
+	if (role == Qt::DisplayRole) {
+		ShoppingListData::const_iterator item = getItem(index);
+		int column = index.column();
 
-	switch (column) {
-		case ITEM_NAME_COL:
-			return QVariant(item.key());
-		case ITEM_PRICE_COL:
-			return QVariant(item->second);
-		case ITEM_AMOUNT_COL:
-			return QVariant(item->first);
+		switch (column) {
+			case ITEM_NAME_COL:
+				return QVariant(item.key());
+			case ITEM_PRICE_COL:
+				return QVariant(item->second);
+			case ITEM_AMOUNT_COL:
+				return QVariant(item->first);
+		}
+	}
+
+	return QVariant(QVariant::Invalid);
+}
+
+Qt::ItemFlags ShoppingList::flags(const QModelIndex &index) const
+{
+	if (index.column() == ITEM_AMOUNT_COL) {
+		return Qt::ItemIsEnabled | Qt::ItemIsEditable;
+	} else {
+		return Qt::NoItemFlags;
 	}
 }
 
+/**
+ * QAbstractTableModel edit functions.
+ **/
+
+bool ShoppingList::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+	ShoppingListData::iterator item = getItem(index);
+	if (index.column() == ITEM_AMOUNT_COL) {
+		setItemAmount(item.key(), value.toInt());
+		emit dataChanged(index, index);
+		return true;
+	}
+
+	return false;
+}

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -117,7 +117,7 @@ int ShoppingList::rowCount(const QModelIndex &parent) const
 
 int ShoppingList::columnCount(const QModelIndex &parent) const
 {
-	return NUM_SHOPPINGLIST_PROPERTIES + 1;
+	return NUM_SHOPPINGLIST_PROPERTIES + 1; //an extra column for displaying a delete button
 }
 
 QVariant ShoppingList::data(const QModelIndex &index, int role) const

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -15,28 +15,21 @@ ShoppingList::ShoppingList(QObject *parent) : QAbstractTableModel(parent)
 
 void ShoppingList::newItem(QString itemName, double price, int amount)
 {
-	//find whether new row should be added, or whether we should change existing item
-	int row = 0;
-	bool isNewRow = false;
-	if (!items.contains(itemName)) {
+	if (!items.contains(itemName)) { //item is new, will insert new row
 		itemRows.push_back(itemName);
-		row = rowCount();
-		isNewRow = true;
-		beginInsertRows(QModelIndex(), row, row); //alert connected views
-	} else {
-		row = itemRows.lastIndexOf(itemName);
-		isNewRow = false;
-	}
+		int row = rowCount();
 
-	//add/change item
-	setItemPrice(itemName, price);
-	setItemAmount(itemName, amount);
+		beginInsertRows(QModelIndex(), row, row);
+		setItemPrice(itemName, price);
+		setItemAmount(itemName, amount);
+		endInsertRows();
+	} else if (items[itemName].price == price) { //item exists, will add to the existing amount
+		int row = itemRows.lastIndexOf(itemName);
 
-	//alert connected views
-	if (isNewRow) {
-		endInsertRows(); //alert connected views
-	} else {
+		setItemAmount(itemName, items[itemName].amount + amount);
 		emit dataChanged(index(row, 0), index(row, NUM_SHOPPINGLIST_PROPERTIES));
+	} else { //ignore new item, price was not the same
+		return;
 	}
 }
 

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -76,7 +76,7 @@ void ShoppingList::deleteLastAddedItem()
 	deleteItem(getItemName(rowCount()-1));
 }
 
-double ShoppingList::getTotalAmount()
+double ShoppingList::getTotalPrice()
 {
 	double totalAmount = 0;
 	for (int i=0; i < rowCount(); i++) {

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -69,11 +69,6 @@ void ShoppingList::wipeList()
 	}
 }
 
-void ShoppingList::deleteLastAddedItem()
-{
-	deleteItem(getItemName(numItems()-1));
-}
-
 double ShoppingList::getTotalPrice()
 {
 	double totalAmount = 0;
@@ -96,11 +91,6 @@ QString ShoppingList::getItemName(int row) const
 /**
  * QAbstractTableModel subclassing convenience functions.
  **/
-
-void ShoppingList::setItemAmount(const QModelIndex &parent, int amount)
-{
-	setItemAmount(getItemName(parent.row()), amount);
-}
 
 void ShoppingList::deleteItem(const QModelIndex &parent)
 {
@@ -216,6 +206,9 @@ void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewIt
 		//draw price + "kr"
 		option.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
 		painter->drawText(option.rect, option.displayAlignment, "(" + index.data().toString() + " kr)");
+	} else if (index.column() == ITEM_NAME_COL) {
+		option.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
+		painter->drawText(option.rect, option.displayAlignment, index.data().toString());
 	} else if (index.column() == ITEM_DELETEBUTTON_COL) {
 		//draw delete button in its assigned column
 		QStyleOptionButton buttonOptions;
@@ -235,6 +228,7 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	//view for displaying shopping list
 	QTableView *listView = new QTableView;
 	listView->verticalHeader()->hide();
+	listView->horizontalHeader()->hide();
 	listView->setAlternatingRowColors(true);
 	listView->setGridStyle(Qt::NoPen);
 	listView->setModel(list);
@@ -244,6 +238,7 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	//use custom delegate for displaying each item
 	listView->setItemDelegate(new ShoppingListItemDelegate);
 
+	//buttons and labellzzz
 	QPushButton *wipeButton = new QPushButton(qApp->style()->standardIcon(QStyle::SP_DialogResetButton), tr("Wipe list"));
 	currentTotalPrice = new QLabel;
 

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -3,11 +3,11 @@
 ///Number of properties associated with each shopping list item (price, name, amount)
 const int NUM_SHOPPINGLIST_PROPERTIES = 3;
 ///Column index for name in shopping list model
-#define ITEM_NAME_COL 0
+#define ITEM_NAME_COL 1
 ///Column index for price in shopping list model
-#define ITEM_PRICE_COL 1
+#define ITEM_PRICE_COL 2
 ///Column index for amount in shopping list model
-#define ITEM_AMOUNT_COL 2
+#define ITEM_AMOUNT_COL 0
 
 ShoppingList::ShoppingList(QObject *parent) : QAbstractTableModel(parent)
 {
@@ -170,4 +170,43 @@ bool ShoppingList::setData(const QModelIndex &index, const QVariant &value, int 
 	}
 
 	return false;
+}
+
+#include <QGridLayout>
+#include <QTableView>
+#include <QLabel>
+#include <QHeaderView>
+#include <QPainter>
+
+ShoppingListItemDelegate::ShoppingListItemDelegate(QObject *parent) : QStyledItemDelegate(parent)
+{
+}
+
+void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE
+{
+	if (index.column() == ITEM_AMOUNT_COL) {
+		painter->drawText(option.rect, option.displayAlignment, index.data().toString());
+	} else {
+		QStyledItemDelegate::paint(painter, option, index);
+	}
+}
+
+ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QWidget(parent)
+{
+	//view for displaying shopping list
+	QTableView *listView = new QTableView;
+	listView->horizontalHeader()->hide();
+	listView->verticalHeader()->hide();
+	listView->setGridStyle(Qt::NoPen);
+	listView->setModel(list);
+
+	//use custom delegate for displaying each item
+	listView->setItemDelegate(new ShoppingListItemDelegate);
+
+	//layout
+	QGridLayout *layout = new QGridLayout(this);
+	layout->addWidget(new QLabel(tr("Sum: ")), 0, 0);
+	QLabel *currSum = new QLabel("0");
+	layout->addWidget(currSum, 0, 1);
+	layout->addWidget(listView);
 }

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -8,7 +8,7 @@ void ShoppingList::newItem(QString itemName, double price, int amount)
 {
 	if (!items.contains(itemName)) { //item is new, will insert new row
 		itemRows.push_back(itemName);
-		int row = rowCount();
+		int row = numItems();
 
 		beginInsertRows(QModelIndex(), row, row);
 		setItemPrice(itemName, price);
@@ -54,7 +54,7 @@ void ShoppingList::deleteItem(QString itemName)
 void ShoppingList::wipeList()
 {
 	if (items.size() > 0) {
-		beginRemoveRows(QModelIndex(), 0, rowCount()-1);
+		beginRemoveRows(QModelIndex(), 0, numItems()-1);
 
 		items.clear();
 		itemRows.clear();
@@ -65,13 +65,13 @@ void ShoppingList::wipeList()
 
 void ShoppingList::deleteLastAddedItem()
 {
-	deleteItem(getItemName(rowCount()-1));
+	deleteItem(getItemName(numItems()-1));
 }
 
 double ShoppingList::getTotalPrice()
 {
 	double totalAmount = 0;
-	for (int i=0; i < rowCount(); i++) {
+	for (int i=0; i < numItems(); i++) {
 		ShoppingListItem item = items[getItemName(i)];
 		totalAmount += item.amount*item.price;
 	}
@@ -80,7 +80,7 @@ double ShoppingList::getTotalPrice()
 
 QString ShoppingList::getItemName(int row) const
 {
-	if ((row >= 0) && (row < rowCount()) && (rowCount() > 0)) {
+	if ((row >= 0) && (row < numItems()) && (numItems() > 0)) {
 		return itemRows[row];
 	} else {
 		return QString();

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -101,6 +101,11 @@ void ShoppingList::deleteItem(const QModelIndex &parent)
 	deleteItem(getItemName(parent.row()));
 }
 
+int ShoppingList::numItems() const
+{
+	return items.size();
+}
+
 /**
  * Neccessary functions for QAbstractTableModel subclassing.
  **/
@@ -108,7 +113,7 @@ void ShoppingList::deleteItem(const QModelIndex &parent)
 int ShoppingList::rowCount(const QModelIndex &parent) const
 {
 	if (!parent.isValid()) {
-		return items.size();
+		return numItems();
 	}
 
 	return 0;
@@ -189,13 +194,16 @@ ShoppingListItemDelegate::ShoppingListItemDelegate(QObject *parent) : QStyledIte
 {
 }
 
-void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE
+void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &inputOption, const QModelIndex &index) const Q_DECL_OVERRIDE
 {
+	QStyleOptionViewItem option = inputOption;
+	option.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
 	if (index.column() == ITEM_AMOUNT_COL) {
 		painter->drawText(option.rect, option.displayAlignment, index.data().toString() + " x ");
 	} else if (index.column() == ITEM_PRICE_COL) {
+		painter->drawText(option.rect, option.displayAlignment, index.data().toString() + " kr");
 	} else {
-		QStyledItemDelegate::paint(painter, option, index);
+		QStyledItemDelegate::paint(painter, inputOption, index);
 	}
 }
 

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -30,6 +30,7 @@ void ShoppingList::newItem(QString itemName, double price, int amount)
 		isNewRow = false;
 	}
 
+	//add/change item
 	setItemPrice(itemName, price);
 	setItemAmount(itemName, amount);
 

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -20,6 +20,44 @@ void ShoppingList::setItemAmount(QString itemName, int amount)
 	items[itemName].first = amount;
 }
 
+void ShoppingList::deleteItem(QString itemName)
+{
+	items.erase(items.find(itemName));
+}
+
+void ShoppingList::wipeList()
+{
+	items.clear();
+}
+
+/**
+ * QAbstractTableModel subclassing convenience functions.
+ **/
+
+void ShoppingList::setItemAmount(const QModelIndex &parent, int amount)
+{
+	setItemAmount(getItem(parent).key(), amount);
+}
+
+void ShoppingList::deleteItem(const QModelIndex &parent)
+{
+	deleteItem(getItem(parent).key());
+}
+
+ShoppingListDB::const_iterator ShoppingList::getItem(const QModelIndex &parent) const
+{
+	return (items.begin() + parent.row());
+}
+
+ShoppingListDB::iterator ShoppingList::getItem(const QModelIndex &parent)
+{
+	return (items.begin() + parent.row());
+}
+
+/**
+ * Neccessary functions for QAbstractTableModel subclassing.
+ **/
+
 int ShoppingList::rowCount(const QModelIndex &parent) const
 {
 	return items.size();
@@ -45,32 +83,3 @@ QVariant ShoppingList::data(const QModelIndex &index, int role) const
 	}
 }
 
-void ShoppingList::setItemAmount(const QModelIndex &parent, int amount)
-{
-	setItemAmount(getItem(parent).key(), amount);
-}
-
-void ShoppingList::deleteItem(QString itemName)
-{
-	items.erase(items.find(itemName));
-}
-
-void ShoppingList::deleteItem(const QModelIndex &parent)
-{
-	deleteItem(getItem(parent).key());
-}
-
-void ShoppingList::wipeList()
-{
-	items.clear();
-}
-
-ShoppingListDB::const_iterator ShoppingList::getItem(const QModelIndex &parent) const
-{
-	return (items.begin() + parent.row());
-}
-
-ShoppingListDB::iterator ShoppingList::getItem(const QModelIndex &parent)
-{
-	return (items.begin() + parent.row());
-}

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -47,10 +47,17 @@ void ShoppingList::wipeList()
 
 void ShoppingList::deleteLastAddedItem()
 {
+	deleteItem(getItemName(rowCount()-1));
 }
 
 double ShoppingList::getTotalAmount()
 {
+	double totalAmount = 0;
+	for (int i=0; i < rowCount(); i++) {
+		ShoppingListItem item = items[getItemName(i)];
+		totalAmount += item.first*item.second;
+	}
+	return totalAmount;
 }
 
 /**

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -6,6 +6,8 @@ ShoppingList::ShoppingList(QObject *parent) : QAbstractTableModel(parent)
 
 void ShoppingList::newItem(QString itemName, double price, int amount)
 {
+	//TODO: call correct rowChanged, rowInserted functions. 
+
 	setItemPrice(itemName, price);
 	setItemAmount(itemName, amount);
 }
@@ -32,6 +34,14 @@ void ShoppingList::deleteItem(QString itemName)
 void ShoppingList::wipeList()
 {
 	items.clear();
+}
+
+void ShoppingList::deleteLastAddedItem()
+{
+}
+
+double ShoppingList::getTotalAmount()
+{
 }
 
 /**

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -12,12 +12,16 @@ void ShoppingList::newItem(QString itemName, double price, int amount)
 
 void ShoppingList::setItemPrice(QString itemName, double price)
 {
-	items[itemName].second = price;
+	if (price > 0) {
+		items[itemName].second = price;
+	}
 }
 
 void ShoppingList::setItemAmount(QString itemName, int amount)
 {
-	items[itemName].first = amount;
+	if (amount > 0) {
+		items[itemName].first = amount;
+	}
 }
 
 void ShoppingList::deleteItem(QString itemName)

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -44,12 +44,12 @@ void ShoppingList::deleteItem(const QModelIndex &parent)
 	deleteItem(getItem(parent).key());
 }
 
-ShoppingListDB::const_iterator ShoppingList::getItem(const QModelIndex &parent) const
+ShoppingListData::const_iterator ShoppingList::getItem(const QModelIndex &parent) const
 {
 	return (items.begin() + parent.row());
 }
 
-ShoppingListDB::iterator ShoppingList::getItem(const QModelIndex &parent)
+ShoppingListData::iterator ShoppingList::getItem(const QModelIndex &parent)
 {
 	return (items.begin() + parent.row());
 }
@@ -70,7 +70,7 @@ int ShoppingList::columnCount(const QModelIndex &parent) const
 
 QVariant ShoppingList::data(const QModelIndex &index, int role) const
 {
-	ShoppingListDB::const_iterator item = getItem(index);
+	ShoppingListData::const_iterator item = getItem(index);
 	int column = index.column();
 
 	switch (column) {

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -149,23 +149,6 @@ Qt::ItemFlags ShoppingList::flags(const QModelIndex &index) const
 	}
 }
 
-QVariant ShoppingList::headerData(int section, Qt::Orientation orientation, int role) const
-{
-	if ((orientation == Qt::Horizontal) && (role == Qt::DisplayRole)) {
-		switch (section) {
-			case ITEM_NAME_COL:
-				return QVariant(tr("Name"));
-			case ITEM_PRICE_COL:
-				return QVariant(tr("Price"));
-			case ITEM_AMOUNT_COL:
-				return QVariant(tr("Amount"));
-		}
-		return QVariant("");
-	}
-
-	return QAbstractTableModel::headerData(section, orientation, role);
-}
-
 /**
  * QAbstractTableModel edit functions.
  **/

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -261,10 +261,18 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	//connections
 	connect(list, SIGNAL(totalPriceChanged()), SLOT(updateDisplayPrice()));
 	connect(wipeButton, SIGNAL(clicked()), list, SLOT(wipeList()));
+	connect(listView, SIGNAL(clicked(const QModelIndex &)), SLOT(deleteShoppingListRow(const QModelIndex &)));
 }
 
 void ShoppingListWidget::updateDisplayPrice()
 {
 	double currPrice = shoppingList->getTotalPrice();
 	currentTotalPrice->setText("Sum: " + QString::number(currPrice) + " kr");
+}
+
+void ShoppingListWidget::deleteShoppingListRow(const QModelIndex &index)
+{
+	if (index.isValid() && (index.column() == ITEM_DELETEBUTTON_COL)) {
+		shoppingList->deleteItem(index);
+	}
 }

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -48,14 +48,27 @@ void ShoppingList::setItemAmount(QString itemName, int amount)
 
 void ShoppingList::deleteItem(QString itemName)
 {
-	items.erase(items.find(itemName));
-	itemRows.erase(itemRows.begin() + itemRows.lastIndexOf(itemName));
+	if (items.contains(itemName)) {
+		int row = itemRows.lastIndexOf(itemName);
+		beginRemoveRows(QModelIndex(), row, row);
+
+		items.erase(items.find(itemName));
+		itemRows.erase(itemRows.begin() + row);
+
+		endRemoveRows();
+	}
 }
 
 void ShoppingList::wipeList()
 {
-	items.clear();
-	itemRows.clear();
+	if (items.size() > 0) {
+		beginRemoveRows(QModelIndex(), 0, rowCount()-1);
+
+		items.clear();
+		itemRows.clear();
+
+		endRemoveRows();
+	}
 }
 
 void ShoppingList::deleteLastAddedItem()

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -95,6 +95,15 @@ double ShoppingList::getTotalPrice()
 	return totalAmount;
 }
 
+QString ShoppingList::getItemName(int row) const
+{
+	if ((row >= 0) && (row < rowCount()) && (rowCount() > 0)) {
+		return itemRows[row];
+	} else {
+		return QString();
+	}
+}
+
 /**
  * QAbstractTableModel subclassing convenience functions.
  **/
@@ -169,13 +178,4 @@ bool ShoppingList::setData(const QModelIndex &index, const QVariant &value, int 
 	}
 
 	return false;
-}
-
-QString ShoppingList::getItemName(int row) const
-{
-	if ((row >= 0) && (row < rowCount()) && (rowCount() > 0)) {
-		return itemRows[row];
-	} else {
-		return QString();
-	}
 }

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -1,0 +1,76 @@
+#include "shoppinglist.h"
+
+ShoppingList::ShoppingList(QObject *parent) : QAbstractTableModel(parent)
+{
+}
+
+void ShoppingList::newItem(QString itemName, double price, int amount)
+{
+	setItemPrice(itemName, price);
+	setItemAmount(itemName, amount);
+}
+
+void ShoppingList::setItemPrice(QString itemName, double price)
+{
+	items[itemName].second = price;
+}
+
+void ShoppingList::setItemAmount(QString itemName, int amount)
+{
+	items[itemName].first = amount;
+}
+
+int ShoppingList::rowCount(const QModelIndex &parent) const
+{
+	return items.size();
+}
+
+int ShoppingList::columnCount(const QModelIndex &parent) const
+{
+	return NUM_SHOPPINGLIST_PROPERTIES;
+}
+
+QVariant ShoppingList::data(const QModelIndex &index, int role) const
+{
+	ShoppingListDB::const_iterator item = getItem(index);
+	int column = index.column();
+
+	switch (column) {
+		case ITEM_NAME_COL:
+			return QVariant(item.key());
+		case ITEM_PRICE_COL:
+			return QVariant(item->second);
+		case ITEM_AMOUNT_COL:
+			return QVariant(item->first);
+	}
+}
+
+void ShoppingList::setItemAmount(const QModelIndex &parent, int amount)
+{
+	setItemAmount(getItem(parent).key(), amount);
+}
+
+void ShoppingList::deleteItem(QString itemName)
+{
+	items.erase(items.find(itemName));
+}
+
+void ShoppingList::deleteItem(const QModelIndex &parent)
+{
+	deleteItem(getItem(parent).key());
+}
+
+void ShoppingList::wipeList()
+{
+	items.clear();
+}
+
+ShoppingListDB::const_iterator ShoppingList::getItem(const QModelIndex &parent) const
+{
+	return (items.begin() + parent.row());
+}
+
+ShoppingListDB::iterator ShoppingList::getItem(const QModelIndex &parent)
+{
+	return (items.begin() + parent.row());
+}

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -22,14 +22,14 @@ void ShoppingList::newItem(QString itemName, double price, int amount)
 void ShoppingList::setItemPrice(QString itemName, double price)
 {
 	if (price > 0) {
-		items[itemName].second = price;
+		items[itemName].price = price;
 	}
 }
 
 void ShoppingList::setItemAmount(QString itemName, int amount)
 {
 	if (amount > 0) {
-		items[itemName].first = amount;
+		items[itemName].amount = amount;
 	}
 }
 
@@ -55,7 +55,7 @@ double ShoppingList::getTotalAmount()
 	double totalAmount = 0;
 	for (int i=0; i < rowCount(); i++) {
 		ShoppingListItem item = items[getItemName(i)];
-		totalAmount += item.first*item.second;
+		totalAmount += item.amount*item.price;
 	}
 	return totalAmount;
 }
@@ -103,9 +103,9 @@ QVariant ShoppingList::data(const QModelIndex &index, int role) const
 			case ITEM_NAME_COL:
 				return itemName;
 			case ITEM_PRICE_COL:
-				return item.second;
+				return item.price;
 			case ITEM_AMOUNT_COL:
-				return item.first;
+				return item.amount;
 		}
 	}
 

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -11,7 +11,12 @@ const int NUM_SHOPPINGLIST_PROPERTIES = 3;
 ///Column index for amount in shopping list model
 #define ITEM_AMOUNT_COL 2
 
-typedef std::pair<int, double> ShoppingListItem;
+
+typedef struct {
+	int amount;
+	double price;
+} ShoppingListItem;
+
 typedef QMap<QString, ShoppingListItem> ShoppingListData;
 
 class ShoppingList : public QAbstractTableModel {
@@ -84,7 +89,6 @@ class ShoppingList : public QAbstractTableModel {
 		///List over shopping list entries
 		ShoppingListData items;
 		///Shopping list row number associated with each entry
-//		ShoppingListDataRows itemRows;
 		QVector<QString> itemRows;
 
 		/**

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -137,20 +137,6 @@ class ShoppingList : public QAbstractTableModel {
 		void wipeList();
 
 		/**
-		 * Delete last added (new) item.
-		 **/
-		void deleteLastAddedItem();
-
-		/**
-		 * \ingroup TableModelFunctions
-		 * Convenience function for setting item amount from a QAbstractItemView-derived subclass.
-		 *
-		 * \param index Item index, see documentation for data()
-		 * \param amount New amount of item at the specified row-number
-		 **/
-		void setItemAmount(const QModelIndex &index, int amount);
-
-		/**
 		 * \ingroup TableModelFunctions
 		 * Convenience function for deleting an item from a QAbstractItemView-derived subclass.
 		 *

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -13,11 +13,6 @@ typedef struct {
 } ShoppingListItem;
 
 /**
- * Shopping list, ordered by shopping list item name.
- **/
-typedef QMap<QString, ShoppingListItem> ShoppingListData;
-
-/**
  * Data structure for containing a shoppinglist. Inherits from QAbstractTableModel, and is
  * thus ready for display in a QAbstractItemView-derived widget.
  **/
@@ -81,8 +76,8 @@ class ShoppingList : public QAbstractTableModel {
 		void setItemAmount(const QModelIndex &index, int amount);
 		void deleteItem(const QModelIndex &index);
 	private:
-		///List over shopping list entries
-		ShoppingListData items;
+		///List over shopping list entries, ordered by item name
+		QMap<QString, ShoppingListItem> items;
 		///Shopping list row numbers, for associating a well-defined row ordering with the shopping list
 		QVector<QString> itemRows;
 

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -37,8 +37,8 @@ class ShoppingList : public QAbstractTableModel {
 		virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-		bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-		Qt::ItemFlags flags(const QModelIndex &index) const;
+		virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+		virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	public slots:
 		/**
 		 * Add new item to shopping list. (Will replace any existing items

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -206,4 +206,5 @@ class ShoppingListWidget : public QWidget {
 		QLabel *currentTotalPrice;
 	private slots:
 		void updateDisplayPrice();
+		void deleteShoppingListRow(const QModelIndex &index);
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -4,9 +4,11 @@
 
 ///Number of properties associated with each shopping list item (price, name, amount)
 const int NUM_SHOPPINGLIST_PROPERTIES = 3;
-
+///Column index for name in shopping list model
 #define ITEM_NAME_COL 0
+///Column index for price in shopping list model
 #define ITEM_PRICE_COL 1
+///Column index for amount in shopping list model
 #define ITEM_AMOUNT_COL 2
 
 typedef QMap<QString, std::pair<int, double> > ShoppingListDB;
@@ -15,27 +17,79 @@ class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT
 	public:
 		ShoppingList(QObject *parent = NULL);
+		
+		/**
+		 * Get total amount in shopping list.
+		 **/
+		double getTotalAmount();
 
+		/**
+		 * Neccessary functions for QAbstractTableModel subclassing (read-only).
+		 **/
 		virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-		double getTotalAmount();
 	public slots:
+		/**
+		 * Add new item to shopping list. (Will replace any existing items
+		 * with same name.)
+		 *
+		 * \param itemName Name of item (unique)
+		 * \param price Item price
+		 * \param amount Item amount
+		 **/
 		void newItem(QString itemName, double price, int amount = 1);
-		void setItemAmount(QString itemName, int amount);
-		void setItemAmount(const QModelIndex &parent, int amount);
 
+		/**
+		 * Set new amount for item.
+		 *
+		 * \param itemName Item name
+		 * \param amount Amount
+		 **/
+		void setItemAmount(QString itemName, int amount);
+
+		/**
+		 * Convenience function for setting amount from a view.
+		 *
+		 * \param parent Model index
+		 * \param amount Amount
+		 **/
+		void setItemAmount(const QModelIndex &index, int amount);
+
+		/**
+		 * Delete item from shopping list.
+		 *
+		 * \param itemName Item
+		 **/
 		void deleteItem(QString itemName);
+
+		/**
+		 * Convenience function for deleting item from list from a view.
+		 **/
 		void deleteItem(const QModelIndex &parent);
 
+		/**
+		 * Wipe entire shopping list.
+		 **/
 		void wipeList();
 //		void deleteLastAddedItem();
 	private:
-		///List over prices associated with each item. Contained here
-		//since price menu can potentially have arbitrary prices for
-		//each unit, and the price list will not contain these.
+		///Shopping list data structure
 		ShoppingListDB items;
+
+		/**
+		 * Set price of item.
+		 *
+		 * \param itemName Item
+		 * \param price New price
+		 **/
 		void setItemPrice(QString itemName, double price);
-		ShoppingListDB::const_iterator getItem(const QModelIndex &parent) const;
-		ShoppingListDB::iterator getItem(const QModelIndex &parent);
+
+		/**
+		 * Get iterator to item in shopping list. Used for model/view convenience.
+		 *
+		 * \param index Index
+		 **/
+		ShoppingListDB::const_iterator getItem(const QModelIndex &index) const;
+		ShoppingListDB::iterator getItem(const QModelIndex &index);
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -17,7 +17,7 @@ class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT
 	public:
 		ShoppingList(QObject *parent = NULL);
-		
+
 		/**
 		 * Get total amount in shopping list.
 		 **/

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -11,7 +11,7 @@ const int NUM_SHOPPINGLIST_PROPERTIES = 3;
 ///Column index for amount in shopping list model
 #define ITEM_AMOUNT_COL 2
 
-typedef QMap<QString, std::pair<int, double> > ShoppingListDB;
+typedef QMap<QString, std::pair<int, double> > ShoppingListData;
 
 class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT
@@ -75,7 +75,7 @@ class ShoppingList : public QAbstractTableModel {
 //		void deleteLastAddedItem();
 	private:
 		///Shopping list data structure
-		ShoppingListDB items;
+		ShoppingListData items;
 
 		/**
 		 * Set price of item.
@@ -90,6 +90,6 @@ class ShoppingList : public QAbstractTableModel {
 		 *
 		 * \param index Index
 		 **/
-		ShoppingListDB::const_iterator getItem(const QModelIndex &index) const;
-		ShoppingListDB::iterator getItem(const QModelIndex &index);
+		ShoppingListData::const_iterator getItem(const QModelIndex &index) const;
+		ShoppingListData::iterator getItem(const QModelIndex &index);
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -2,6 +2,15 @@
 #include <QAbstractTableModel>
 #include <QMap>
 
+///Number of properties associated with each shopping list item (price, name, amount)
+const int NUM_SHOPPINGLIST_PROPERTIES = 3;
+///Column index for name in shopping list model
+#define ITEM_NAME_COL 1
+///Column index for price in shopping list model
+#define ITEM_PRICE_COL 2
+///Column index for amount in shopping list model
+#define ITEM_AMOUNT_COL 0
+
 /**
  * Item in shopping list.
  **/
@@ -81,6 +90,12 @@ class ShoppingList : public QAbstractTableModel {
 		 * \return Enabled and editable if the index corresponds to an amount for a shopping list item, disabled otherwise
 		 **/
 		virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Reimplemented from QAbstractItemModel. Returns custom headers for the horizontal orientation.
+		 **/
+		virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 	public slots:
 		/**
 		 * Add new item to shopping list. Item names function as unique identifiers:

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -90,7 +90,7 @@ class ShoppingList : public QAbstractTableModel {
 		void setItemPrice(QString itemName, double price);
 
 		/**
-		 * Get item name associated with a given position.
+		 * Get item name associated with a given row along itemRows.
 		 *
 		 * \param row Row number
 		 **/

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -189,22 +189,53 @@ class ShoppingList : public QAbstractTableModel {
 
 class QLabel;
 
+/**
+ * Shopping list widget. Uses a QTableView to display the supplied
+ * shopping list data model. Uses ShoppingListItemDelegate to draw
+ * each shopping list item.
+ **/
+class ShoppingListWidget : public QWidget {
+	Q_OBJECT
+	public:
+		/**
+		 * Creates the table for displaying the shopping list.
+		 *
+		 * \param list Shopping list
+		 **/
+		ShoppingListWidget(ShoppingList *list, QWidget *parent = NULL);
+	private:
+		///Convenience pointer to the canonical shopping list
+		ShoppingList *shoppingList;
+		///Label for displaying the current total price of items in shopping list
+		QLabel *currentTotalPrice;
+	private slots:
+		/**
+		 * Signal that price displayed in currentTotalPrice should be recalculated from shoppingList.
+		 **/
+		void updateDisplayPrice();
+
+		/**
+		 * Delete shopping list item corresponding to the specified index, given that index.column() corresponds to ITEM_DELETEBUTTON_ROW (user clicked on the cell corresponding to the delete button).
+		 *
+		 * \param index Index
+		 **/
+		void deleteShoppingListRow(const QModelIndex &index);
+};
+
+/**
+ * Used for drawing shopping list rows in the shopping list widget.
+ **/
 class ShoppingListItemDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 	public:
 		ShoppingListItemDelegate(QObject *parent = NULL);
+
+		/**
+		 * Reimplemented from QStyledItemDelegate. Special functionality:
+		 * - Draws amount as "NN x"
+		 * - Draws price as "(NN kr)"
+		 * - In ITEM_DELETEBUTTON_COL column, a delete button is _drawn_.
+		 * It is assumed that actual button clicking in the cell is handled elsewhere (i.e. in ShoppingListWidget).
+		 **/
 		virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
-};
-
-
-class ShoppingListWidget : public QWidget {
-	Q_OBJECT
-	public:
-		ShoppingListWidget(ShoppingList *list, QWidget *parent = NULL);
-	private:
-		ShoppingList *shoppingList;
-		QLabel *currentTotalPrice;
-	private slots:
-		void updateDisplayPrice();
-		void deleteShoppingListRow(const QModelIndex &index);
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -46,12 +46,12 @@ class ShoppingList : public QAbstractTableModel {
 		 *
 		 * \param itemName Name of item (unique)
 		 * \param price Item price
-		 * \param amount Item amount
+		 * \param amount Item amount (number of items)
 		 **/
 		void newItem(QString itemName, double price, int amount = 1);
 
 		/**
-		 * Set new amount for item.
+		 * Set new amount of item.
 		 *
 		 * \param itemName Item name
 		 * \param amount Amount

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -156,3 +156,20 @@ class ShoppingList : public QAbstractTableModel {
 		 **/
 		QString getItemName(int row) const;
 };
+
+#include <QWidget>
+#include <QStyledItemDelegate>
+
+class ShoppingListItemDelegate : public QStyledItemDelegate {
+	Q_OBJECT
+	public:
+		ShoppingListItemDelegate(QObject *parent = NULL);
+		virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
+};
+
+
+class ShoppingListWidget : public QWidget {
+	Q_OBJECT
+	public:
+		ShoppingListWidget(ShoppingList *list, QWidget *parent = NULL);
+};

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -29,6 +29,8 @@ class ShoppingList : public QAbstractTableModel {
 		virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+		bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+		Qt::ItemFlags flags(const QModelIndex &index) const;
 	public slots:
 		/**
 		 * Add new item to shopping list. (Will replace any existing items

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -4,6 +4,8 @@
 
 ///Number of properties associated with each shopping list item (price, name, amount)
 const int NUM_SHOPPINGLIST_PROPERTIES = 3;
+///Column index for row delete button
+#define ITEM_DELETEBUTTON_COL 3
 ///Column index for name in shopping list model
 #define ITEM_NAME_COL 1
 ///Column index for price in shopping list model

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -17,6 +17,9 @@ typedef struct {
  * thus ready for display in a QAbstractItemView-derived widget.
  *
  * New items should be added by connecting to the ShoppingList::newItem()-SLOT.
+ *
+ * ShoppingList will notify any containing View with changes when any modifications
+ * are made to the list.
  **/
 class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -73,7 +73,7 @@ class ShoppingList : public QAbstractTableModel {
 		 * \ingroup TableModelFunctions
 		 * Data access function. Necessary for QAbstractTableModel subclassing. Implements only Qt::DisplayRole.
 		 *
-		 * \param index Index in table. row is assumed to correspond to position in the shopping list, while columns 0, 1 and 2 correspond to name, price and amount (see also ITEM_NAME_COL etc. defined in shoppinglist.cpp)
+		 * \param index Index in table. row is assumed to correspond to position in the shopping list. Which item property (name, price, amount) will appear in which column is defined by ITEM_NAME_COL, ITEM_PRICE_COL and ITEM_AMOUNT_COL constants
 		 * \param role Role, see Qt docs for QAbstractItemModel
 		 * \return Name, price, amount or QVariant(QVariant::Invalid) depending on column index
 		 **/

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -113,7 +113,7 @@ class ShoppingList : public QAbstractTableModel {
 		void wipeList();
 
 		/**
-		 * Delete last added item.
+		 * Delete last added (new) item.
 		 **/
 		void deleteLastAddedItem();
 

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -175,10 +175,17 @@ class ShoppingList : public QAbstractTableModel {
 		 * \param row Row number
 		 **/
 		QString getItemName(int row) const;
+	signals:
+		/**
+		 * Emitted whenever the total price changes. Emitted from newItem() and setData().
+		 **/
+		void totalPriceChanged();
 };
 
 #include <QWidget>
 #include <QStyledItemDelegate>
+
+class QLabel;
 
 class ShoppingListItemDelegate : public QStyledItemDelegate {
 	Q_OBJECT
@@ -192,4 +199,9 @@ class ShoppingListWidget : public QWidget {
 	Q_OBJECT
 	public:
 		ShoppingListWidget(ShoppingList *list, QWidget *parent = NULL);
+	private:
+		ShoppingList *shoppingList;
+		QLabel *currentTotalPrice;
+	private slots:
+		void updateDisplayPrice();
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -2,15 +2,6 @@
 #include <QAbstractItemModel>
 #include <QMap>
 
-///Number of properties associated with each shopping list item (price, name, amount)
-const int NUM_SHOPPINGLIST_PROPERTIES = 3;
-///Column index for name in shopping list model
-#define ITEM_NAME_COL 0
-///Column index for price in shopping list model
-#define ITEM_PRICE_COL 1
-///Column index for amount in shopping list model
-#define ITEM_AMOUNT_COL 2
-
 /**
  * Item in shopping list.
  **/

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -11,7 +11,8 @@ const int NUM_SHOPPINGLIST_PROPERTIES = 3;
 ///Column index for amount in shopping list model
 #define ITEM_AMOUNT_COL 2
 
-typedef QMap<QString, std::pair<int, double> > ShoppingListData;
+typedef std::pair<int, double> ShoppingListItem;
+typedef QMap<QString, ShoppingListItem> ShoppingListData;
 
 class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT
@@ -80,8 +81,11 @@ class ShoppingList : public QAbstractTableModel {
 		 **/
 		void deleteLastAddedItem();
 	private:
-		///Shopping list data structure
+		///List over shopping list entries
 		ShoppingListData items;
+		///Shopping list row number associated with each entry
+//		ShoppingListDataRows itemRows;
+		QVector<QString> itemRows;
 
 		/**
 		 * Set price of item.
@@ -91,11 +95,5 @@ class ShoppingList : public QAbstractTableModel {
 		 **/
 		void setItemPrice(QString itemName, double price);
 
-		/**
-		 * Get iterator to item in shopping list. Used for model/view convenience.
-		 *
-		 * \param index Index
-		 **/
-		ShoppingListData::const_iterator getItem(const QModelIndex &index) const;
-		ShoppingListData::iterator getItem(const QModelIndex &index);
+		QString getItemName(int row) const;
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -27,12 +27,55 @@ class ShoppingList : public QAbstractTableModel {
 		double getTotalPrice();
 
 		/**
-		 * Neccessary functions for QAbstractTableModel subclassing.
+		 * \defgroup TableModelFunctions QAbstractTableModel subclassing
+		 * Functions related to the QAbstractTableModel subclassing.
+		 **/
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Number of rows in the table model represented by ShoppingList. Necessary for QAbstractTableModel subclassing.
+		 *
+		 * \param parent Parent index
+		 * \return Number of items in shopping list
 		 **/
 		virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Number of columns in the table model. Necessary for QAbstractTableModel subclassing.
+		 *
+		 * \param parent Parent index
+		 * \return Always 3 (name + price + amount)
+		 **/
 		virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Data access function. Necessary for QAbstractTableModel subclassing. Implements only Qt::DisplayRole.
+		 *
+		 * \param index Index in table. row is assumed to correspond to position in the shopping list, while columns 0, 1 and 2 correspond to name, price and amount (see also ITEM_NAME_COL etc. defined in shoppinglist.cpp)
+		 * \param role Role, see Qt docs for QAbstractItemModel
+		 * \return Name, price, amount or QVariant(QVariant::Invalid) depending on column index
+		 **/
 		virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Data setting function. Necessary for QAbstractTableModel subclassing. Implements only Qt::EditRole, allows editing only for the amount of an already inserted item.
+		 *
+		 * \param index Index in table, see documentation for data()
+		 * \param value New value for the specified table position
+		 * \param role Role
+		 **/
 		virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Item flags for the defined table indices.
+		 *
+		 * \param index Index, see documentation for data()
+		 * \return Enabled and editable if the index corresponds to an amount for a shopping list item, disabled otherwise
+		 **/
 		virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	public slots:
 		/**
@@ -71,9 +114,20 @@ class ShoppingList : public QAbstractTableModel {
 		void deleteLastAddedItem();
 
 		/**
-		 * Convenience functions for QAbstractItemView-derived subclasses.
+		 * \ingroup TableModelFunctions
+		 * Convenience function for setting item amount from a QAbstractItemView-derived subclass.
+		 *
+		 * \param index Item index, see documentation for data()
+		 * \param amount New amount of item at the specified row-number
 		 **/
 		void setItemAmount(const QModelIndex &index, int amount);
+
+		/**
+		 * \ingroup TableModelFunctions
+		 * Convenience function for deleting an item from a QAbstractItemView-derived subclass.
+		 *
+		 * \param index Item index, see documentation for data()
+		 **/
 		void deleteItem(const QModelIndex &index);
 	private:
 		///List over shopping list entries, ordered by item name

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -11,12 +11,19 @@ const int NUM_SHOPPINGLIST_PROPERTIES = 3;
 ///Column index for amount in shopping list model
 #define ITEM_AMOUNT_COL 2
 
-
+/**
+ * Item in shopping list.
+ **/
 typedef struct {
+	///Amount of item
 	int amount;
+	///Price of item
 	double price;
 } ShoppingListItem;
 
+/**
+ * Shopping list, ordered by shopping list item name.
+ **/
 typedef QMap<QString, ShoppingListItem> ShoppingListData;
 
 /**
@@ -29,9 +36,9 @@ class ShoppingList : public QAbstractTableModel {
 		ShoppingList(QObject *parent = NULL);
 
 		/**
-		 * Get total amount in shopping list.
+		 * Get total price of all items in shopping list.
 		 **/
-		double getTotalAmount();
+		double getTotalPrice();
 
 		/**
 		 * Neccessary functions for QAbstractTableModel subclassing.
@@ -61,24 +68,11 @@ class ShoppingList : public QAbstractTableModel {
 		void setItemAmount(QString itemName, int amount);
 
 		/**
-		 * Convenience function for setting amount from a QAbstractItemView-derived class.
-		 *
-		 * \param index Model index
-		 * \param amount Amount
-		 **/
-		void setItemAmount(const QModelIndex &index, int amount);
-
-		/**
 		 * Delete item from shopping list.
 		 *
 		 * \param itemName Item
 		 **/
 		void deleteItem(QString itemName);
-
-		/**
-		 * Convenience function for deleting item from list from a QAbstractItemView-derived class.
-		 **/
-		void deleteItem(const QModelIndex &index);
 
 		/**
 		 * Wipe entire shopping list.
@@ -89,12 +83,16 @@ class ShoppingList : public QAbstractTableModel {
 		 * Delete last added item.
 		 **/
 		void deleteLastAddedItem();
+
+		/**
+		 * Convenience functions for QAbstractItemView-derived subclasses.
+		 **/
+		void setItemAmount(const QModelIndex &index, int amount);
+		void deleteItem(const QModelIndex &index);
 	private:
 		///List over shopping list entries
 		ShoppingListData items;
-		///Shopping list row number associated with each entry in the
-		///shopping list, in order to have a well-defined ordering of
-		///the elements
+		///Shopping list row numbers, for associating a well-defined row ordering with the shopping list
 		QVector<QString> itemRows;
 
 		/**

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -97,12 +97,6 @@ class ShoppingList : public QAbstractTableModel {
 		 * \return Enabled and editable if the index corresponds to an amount for a shopping list item, disabled otherwise
 		 **/
 		virtual Qt::ItemFlags flags(const QModelIndex &index) const;
-
-		/**
-		 * \ingroup TableModelFunctions
-		 * Reimplemented from QAbstractItemModel. Returns custom headers for the horizontal orientation.
-		 **/
-		virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 	public slots:
 		/**
 		 * Add new item to shopping list. Item names function as unique identifiers:

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -193,6 +193,9 @@ class QLabel;
  * Shopping list widget. Uses a QTableView to display the supplied
  * shopping list data model. Uses ShoppingListItemDelegate to draw
  * each shopping list item.
+ *
+ * This is the class that is used for /drawing/ the shopping list,
+ * while all shopping list /data handling/ is done in ShoppingList.
  **/
 class ShoppingListWidget : public QWidget {
 	Q_OBJECT

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -18,8 +18,7 @@ typedef struct {
  *
  * New items should be added by connecting to the ShoppingList::newItem()-SLOT.
  *
- * ShoppingList will notify any containing View with changes when any modifications
- * are made to the list.
+ * ShoppingList will notify any connected View with changes.
  **/
 class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -1,5 +1,5 @@
 #include <QObject>
-#include <QAbstractItemModel>
+#include <QAbstractTableModel>
 #include <QMap>
 
 /**

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -74,7 +74,11 @@ class ShoppingList : public QAbstractTableModel {
 		 * Wipe entire shopping list.
 		 **/
 		void wipeList();
-//		void deleteLastAddedItem();
+
+		/**
+		 * Delete last added item.
+		 **/
+		void deleteLastAddedItem();
 	private:
 		///Shopping list data structure
 		ShoppingListData items;

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -1,0 +1,41 @@
+#include <QObject>
+#include <QAbstractItemModel>
+#include <QMap>
+
+///Number of properties associated with each shopping list item (price, name, amount)
+const int NUM_SHOPPINGLIST_PROPERTIES = 3;
+
+#define ITEM_NAME_COL 0
+#define ITEM_PRICE_COL 1
+#define ITEM_AMOUNT_COL 2
+
+typedef QMap<QString, std::pair<int, double> > ShoppingListDB;
+
+class ShoppingList : public QAbstractTableModel {
+	Q_OBJECT
+	public:
+		ShoppingList(QObject *parent = NULL);
+
+		virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
+		virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
+		virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+		double getTotalAmount();
+	public slots:
+		void newItem(QString itemName, double price, int amount = 1);
+		void setItemAmount(QString itemName, int amount);
+		void setItemAmount(const QModelIndex &parent, int amount);
+
+		void deleteItem(QString itemName);
+		void deleteItem(const QModelIndex &parent);
+
+		void wipeList();
+//		void deleteLastAddedItem();
+	private:
+		///List over prices associated with each item. Contained here
+		//since price menu can potentially have arbitrary prices for
+		//each unit, and the price list will not contain these.
+		ShoppingListDB items;
+		void setItemPrice(QString itemName, double price);
+		ShoppingListDB::const_iterator getItem(const QModelIndex &parent) const;
+		ShoppingListDB::iterator getItem(const QModelIndex &parent);
+};

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -40,6 +40,11 @@ class ShoppingList : public QAbstractTableModel {
 		double getTotalPrice();
 
 		/**
+		 * Get number of items in shopping list.
+		 **/
+		int numItems() const;
+
+		/**
 		 * \defgroup TableModelFunctions QAbstractTableModel subclassing
 		 * Functions related to the QAbstractTableModel subclassing.
 		 **/

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -19,6 +19,10 @@ typedef struct {
 
 typedef QMap<QString, ShoppingListItem> ShoppingListData;
 
+/**
+ * Data structure for containing a shoppinglist. Inherits from QAbstractTableModel, and is
+ * thus ready for display in a QAbstractItemView-derived widget.
+ **/
 class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT
 	public:
@@ -30,7 +34,7 @@ class ShoppingList : public QAbstractTableModel {
 		double getTotalAmount();
 
 		/**
-		 * Neccessary functions for QAbstractTableModel subclassing (read-only).
+		 * Neccessary functions for QAbstractTableModel subclassing.
 		 **/
 		virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 		virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
@@ -57,9 +61,9 @@ class ShoppingList : public QAbstractTableModel {
 		void setItemAmount(QString itemName, int amount);
 
 		/**
-		 * Convenience function for setting amount from a view.
+		 * Convenience function for setting amount from a QAbstractItemView-derived class.
 		 *
-		 * \param parent Model index
+		 * \param index Model index
 		 * \param amount Amount
 		 **/
 		void setItemAmount(const QModelIndex &index, int amount);
@@ -72,9 +76,9 @@ class ShoppingList : public QAbstractTableModel {
 		void deleteItem(QString itemName);
 
 		/**
-		 * Convenience function for deleting item from list from a view.
+		 * Convenience function for deleting item from list from a QAbstractItemView-derived class.
 		 **/
-		void deleteItem(const QModelIndex &parent);
+		void deleteItem(const QModelIndex &index);
 
 		/**
 		 * Wipe entire shopping list.
@@ -88,7 +92,9 @@ class ShoppingList : public QAbstractTableModel {
 	private:
 		///List over shopping list entries
 		ShoppingListData items;
-		///Shopping list row number associated with each entry
+		///Shopping list row number associated with each entry in the
+		///shopping list, in order to have a well-defined ordering of
+		///the elements
 		QVector<QString> itemRows;
 
 		/**
@@ -99,5 +105,10 @@ class ShoppingList : public QAbstractTableModel {
 		 **/
 		void setItemPrice(QString itemName, double price);
 
+		/**
+		 * Get item name associated with a given position.
+		 *
+		 * \param row Row number
+		 **/
 		QString getItemName(int row) const;
 };

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -15,6 +15,8 @@ typedef struct {
 /**
  * Data structure for containing a shoppinglist. Inherits from QAbstractTableModel, and is
  * thus ready for display in a QAbstractItemView-derived widget.
+ *
+ * New items should be added by connecting to the ShoppingList::newItem()-SLOT.
  **/
 class ShoppingList : public QAbstractTableModel {
 	Q_OBJECT
@@ -79,12 +81,14 @@ class ShoppingList : public QAbstractTableModel {
 		virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	public slots:
 		/**
-		 * Add new item to shopping list. (Will replace any existing items
-		 * with same name.)
+		 * Add new item to shopping list. Item names function as unique identifiers:
+		 * 	- If the price is the same: Assumed that the item is the same, the input amount is
+		 * 	  added to the existing item amount
+		 * 	- If the price is different: This should happen, so the new item is ignored. :-P
 		 *
 		 * \param itemName Name of item (unique)
 		 * \param price Item price
-		 * \param amount Item amount (number of items)
+		 * \param amount Item amount (number of items, is accumulated to the item each time the SLOT is called)
 		 **/
 		void newItem(QString itemName, double price, int amount = 1);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,10 +9,14 @@ MACRO (add_qt_test testname testsrc)
 
 	include_directories(../daemon)
 
-	add_executable(test_${testname} ${test_${testname}_SRCS} ../src/daemon_client.cpp ../src/cardreader.cpp)
-	target_link_libraries(test_${testname} Qt5::Test Qt5::DBus Qt5::Widgets)
+	add_executable(test_${testname} ${test_${testname}_SRCS})
+	target_link_libraries(test_${testname} Qt5::Test Qt5::DBus Qt5::Widgets digcross_test_common)
 	ADD_TEST(test_${testname} test_${testname})
 ENDMACRO (add_qt_test)
 
+add_library(digcross_test_common ../src/daemon_client.cpp ../src/cardreader.cpp ../src/shoppinglist.cpp)
+target_link_libraries(digcross_test_common Qt5::Test Qt5::DBus Qt5::Widgets)
+
 add_qt_test(daemonclient daemon_client-t.cpp)
 add_qt_test(cardreader cardreader-t.cpp)
+add_qt_test(shoppinglist shoppinglist-t.cpp)

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -102,24 +102,6 @@ void ShoppingListTest::testWipeList()
 	QCOMPARE(shoppingList->numItems(), 0);
 }
 
-void ShoppingListTest::testDeleteLastItem()
-{
-	shoppingList->newItem("something_different", 20, 20);
-	QCOMPARE(shoppingList->numItems(), 4);
-
-	//verify that last item was deleted
-	shoppingList->deleteLastAddedItem();
-	QCOMPARE(shoppingList->numItems(), 3);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), ITEM_1);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), ITEM_2);
-	QCOMPARE(shoppingList->data(shoppingList->index(2, ITEM_NAME_COL)).toString(), ITEM_3);
-
-	//test deleteLastItem on empty list
-	delete shoppingList;
-	shoppingList = new ShoppingList;
-	shoppingList->deleteLastAddedItem();
-}
-
 void ShoppingListTest::testGetTotalPrice()
 {
 	shoppingList->wipeList();

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -3,11 +3,20 @@
 #include "shoppinglist.h"
 #include <QTableView>
 
+const QString ITEM_1 = "test_item_1";
+const QString ITEM_2 = "test_item_2";
+const QString ITEM_3 = "test_item_3";
+const double PRICE = 20.0;
+const int AMOUNT = 20;
+
 void ShoppingListTest::init()
 {
 	shoppingList = new ShoppingList;
 
-	//TODO: Since all tests mostly use the same data, populate the shoppingList here.
+	//add test data
+	shoppingList->newItem(ITEM_1, PRICE, AMOUNT);
+	shoppingList->newItem(ITEM_2, PRICE, AMOUNT);
+	shoppingList->newItem(ITEM_3, PRICE, AMOUNT);
 }
 
 void ShoppingListTest::cleanup()
@@ -17,6 +26,10 @@ void ShoppingListTest::cleanup()
 
 void ShoppingListTest::testNewItem()
 {
+	//start from scratch (ignore test data created in init()
+	delete shoppingList;
+	shoppingList = new ShoppingList;
+
 	QString item_1 = "test_item";
 	QString item_2 = "test_item_2";
 
@@ -49,44 +62,30 @@ void ShoppingListTest::testNewItem()
 
 void ShoppingListTest::testSetItemAmount()
 {
-	int amount = 20;
-	shoppingList->newItem("test_item_1", 20.0, amount);
-	shoppingList->newItem("test_item_2", 20.0, amount);
-	shoppingList->newItem("test_item_3", 20.0, amount);
-
-	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), amount);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), AMOUNT);
 
 	//check that the amount is changed when requested
-	shoppingList->setItemAmount("test_item_3", amount*2);
-	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), amount*2);
+	shoppingList->setItemAmount(ITEM_3, AMOUNT*2);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), AMOUNT*2);
 }
 
 void ShoppingListTest::testDeleteItem()
 {
-	int amount = 20;
-	shoppingList->newItem("test_item_1", 20.0, amount);
-	shoppingList->newItem("test_item_2", 20.0, amount);
-	shoppingList->newItem("test_item_3", 20.0, amount);
-
 	QCOMPARE(shoppingList->rowCount(), 3);
 
 	//check that correct row is deleted when using the item name
-	shoppingList->deleteItem("test_item_2");
+	shoppingList->deleteItem(ITEM_2);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), QString("test_item_1"));
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), QString("test_item_3"));
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_1);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), ITEM_3);
 
 	//check that the correct row is deleted when using the row number
 	shoppingList->deleteItem(shoppingList->index(0, 0));
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), QString("test_item_3"));
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_3);
 }
 
 void ShoppingListTest::testWipeList()
 {
-	int amount = 20;
-	shoppingList->newItem("test_item_1", 20.0, amount);
-	shoppingList->newItem("test_item_2", 20.0, amount);
-	shoppingList->newItem("test_item_3", 20.0, amount);
 	QCOMPARE(shoppingList->rowCount(), 3);
 
 	//verify that list is wiped
@@ -99,29 +98,29 @@ void ShoppingListTest::testWipeList()
 
 void ShoppingListTest::testDeleteLastItem()
 {
-	int amount = 20;
-	shoppingList->newItem("test_item_1", 20.0, amount);
-	shoppingList->newItem("test_item_2", 20.0, amount);
-	shoppingList->newItem("test_item_3", 20.0, amount);
-	QCOMPARE(shoppingList->rowCount(), 3);
+	shoppingList->newItem("something_different", 20, 20);
+	QCOMPARE(shoppingList->rowCount(), 4);
 
 	//verify that last item was deleted
 	shoppingList->deleteLastAddedItem();
-	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), QString("test_item_1"));
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), QString("test_item_2"));
+	QCOMPARE(shoppingList->rowCount(), 3);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_1);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), ITEM_2);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, 0)).toString(), ITEM_3);
 }
 
 void ShoppingListTest::testGetTotalAmount()
 {
-	QCOMPARE(shoppingList->getTotalAmount(), 0.0);
+	shoppingList->wipeList();
+	QCOMPARE(shoppingList->rowCount(), 0);
+
 	int amount = 20;
 	double price = 20;
-	shoppingList->newItem("test_item_1", price, amount);
+	shoppingList->newItem(ITEM_1, price, amount);
 	QCOMPARE(shoppingList->getTotalAmount(), price*amount*1.0);
-	shoppingList->newItem("test_item_2", price, amount);
+	shoppingList->newItem(ITEM_2, price, amount);
 	QCOMPARE(shoppingList->getTotalAmount(), 2*price*amount*1.0);
-	shoppingList->newItem("test_item_3", price, amount);
+	shoppingList->newItem(ITEM_3, price, amount);
 	QCOMPARE(shoppingList->getTotalAmount(), 3*price*amount*1.0);
 }
 

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -30,8 +30,8 @@ void ShoppingListTest::testNewItem()
 	delete shoppingList;
 	shoppingList = new ShoppingList;
 
-	QString item_1 = "test_item";
-	QString item_2 = "test_item_2";
+	QString item_1 = "test_item_c";
+	QString item_2 = "test_item_b";
 
 	double price = 20.0;
 	int amount = 10;
@@ -45,7 +45,7 @@ void ShoppingListTest::testNewItem()
 	QCOMPARE(shoppingList->rowCount(), 1);
 	shoppingList->newItem(item_2, price, amount);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), item_1);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), item_2);
 
 	//verify the other elements
 	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price);

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -1,0 +1,126 @@
+#include <QSignalSpy>
+#include "shoppinglist-t.h"
+#include "shoppinglist.h"
+#include <QTableView>
+
+void ShoppingListTest::init()
+{
+	shoppingList = new ShoppingList;
+}
+
+void ShoppingListTest::cleanup()
+{
+	delete shoppingList;
+}
+
+void ShoppingListTest::testNewItem()
+{
+	QString item_1 = "test_item";
+	QString item_2 = "test_item_2";
+
+	double price = 20.0;
+	int amount = 10;
+
+	//basic test of add
+	QCOMPARE(shoppingList->rowCount(), 0);
+	shoppingList->newItem(item_1, price, amount);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), item_1);
+
+	//add another item, verify it is added in a new row
+	QCOMPARE(shoppingList->rowCount(), 1);
+	shoppingList->newItem(item_2, price, amount);
+	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), item_1);
+
+	//verify the other elements
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount);
+
+	//add item with same name, verify it overwrites the former item
+	double price_2 = 30.0;
+	int amount_2 = 30;
+	shoppingList->newItem(item_2, price_2, amount_2);
+	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price_2);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount_2);
+}
+
+void ShoppingListTest::testSetItemAmount()
+{
+	int amount = 20;
+	shoppingList->newItem("test_item_1", 20.0, amount);
+	shoppingList->newItem("test_item_2", 20.0, amount);
+	shoppingList->newItem("test_item_3", 20.0, amount);
+
+	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), amount);
+
+	//check that the amount is changed when requested
+	shoppingList->setItemAmount("test_item_3", amount*2);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), amount*2);
+}
+
+void ShoppingListTest::testDeleteItem()
+{
+	int amount = 20;
+	shoppingList->newItem("test_item_1", 20.0, amount);
+	shoppingList->newItem("test_item_2", 20.0, amount);
+	shoppingList->newItem("test_item_3", 20.0, amount);
+
+	QCOMPARE(shoppingList->rowCount(), 3);
+
+	//check that correct row is deleted when using the item name
+	shoppingList->deleteItem("test_item_2");
+	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), QString("test_item_1"));
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), QString("test_item_3"));
+
+	//check that the correct row is deleted when using the row number
+	shoppingList->deleteItem(shoppingList->index(0, 0));
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), QString("test_item_3"));
+}
+
+void ShoppingListTest::testWipeList()
+{
+	int amount = 20;
+	shoppingList->newItem("test_item_1", 20.0, amount);
+	shoppingList->newItem("test_item_2", 20.0, amount);
+	shoppingList->newItem("test_item_3", 20.0, amount);
+	QCOMPARE(shoppingList->rowCount(), 3);
+
+	//verify that list is wiped
+	shoppingList->wipeList();
+	QCOMPARE(shoppingList->rowCount(), 0);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)), QVariant(QVariant::Invalid));
+	shoppingList->wipeList();
+	QCOMPARE(shoppingList->rowCount(), 0);
+}
+
+void ShoppingListTest::testDeleteLastItem()
+{
+	int amount = 20;
+	shoppingList->newItem("test_item_1", 20.0, amount);
+	shoppingList->newItem("test_item_2", 20.0, amount);
+	shoppingList->newItem("test_item_3", 20.0, amount);
+	QCOMPARE(shoppingList->rowCount(), 3);
+
+	//verify that last item was deleted
+	shoppingList->deleteLastAddedItem();
+	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), QString("test_item_1"));
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), QString("test_item_2"));
+}
+
+void ShoppingListTest::testGetTotalAmount()
+{
+	QCOMPARE(shoppingList->getTotalAmount(), 0.0);
+	int amount = 20;
+	double price = 20;
+	shoppingList->newItem("test_item_1", price, amount);
+	QCOMPARE(shoppingList->getTotalAmount(), price*amount*1.0);
+	shoppingList->newItem("test_item_2", price, amount);
+	QCOMPARE(shoppingList->getTotalAmount(), 2*price*amount*1.0);
+	shoppingList->newItem("test_item_3", price, amount);
+	QCOMPARE(shoppingList->getTotalAmount(), 3*price*amount*1.0);
+}
+
+QTEST_MAIN(ShoppingListTest)

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -113,6 +113,11 @@ void ShoppingListTest::testDeleteLastItem()
 	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_1);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), ITEM_2);
 	QCOMPARE(shoppingList->data(shoppingList->index(2, 0)).toString(), ITEM_3);
+
+	//test deleteLastItem on empty list
+	delete shoppingList;
+	shoppingList = new ShoppingList;
+	shoppingList->deleteLastAddedItem();
 }
 
 void ShoppingListTest::testGetTotalPrice()

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -51,13 +51,19 @@ void ShoppingListTest::testNewItem()
 	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount);
 
-	//add item with same name, verify it overwrites the former item
+	//add item with same name, verify it doesn't overwrite the former item when price is different
 	double price_2 = 30.0;
 	int amount_2 = 30;
 	shoppingList->newItem(item_2, price_2, amount_2);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price_2);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount_2);
+	QVERIFY(shoppingList->data(shoppingList->index(1, 1)).toDouble() != price_2);
+	QVERIFY(shoppingList->data(shoppingList->index(1, 2)).toInt() != amount_2);
+
+	//add item with same name, verify that it adds to the amount when the price is the same
+	shoppingList->newItem(item_2, price, amount_2);
+	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount + amount_2);
 }
 
 void ShoppingListTest::testSetItemAmount()

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -39,40 +39,40 @@ void ShoppingListTest::testNewItem()
 	//basic test of add
 	QCOMPARE(shoppingList->rowCount(), 0);
 	shoppingList->newItem(item_1, price, amount);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), item_1);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), item_1);
 
 	//add another item, verify it is added in a new row
 	QCOMPARE(shoppingList->rowCount(), 1);
 	shoppingList->newItem(item_2, price, amount);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), item_2);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), item_2);
 
 	//verify the other elements
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt(), amount);
 
 	//add item with same name, verify it doesn't overwrite the former item when price is different
 	double price_2 = 30.0;
 	int amount_2 = 30;
 	shoppingList->newItem(item_2, price_2, amount_2);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QVERIFY(shoppingList->data(shoppingList->index(1, 1)).toDouble() != price_2);
-	QVERIFY(shoppingList->data(shoppingList->index(1, 2)).toInt() != amount_2);
+	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble() != price_2);
+	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt() != amount_2);
 
 	//add item with same name, verify that it adds to the amount when the price is the same
 	shoppingList->newItem(item_2, price, amount_2);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 1)).toDouble(), price);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 2)).toInt(), amount + amount_2);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt(), amount + amount_2);
 }
 
 void ShoppingListTest::testSetItemAmount()
 {
-	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), AMOUNT);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, ITEM_AMOUNT_COL)).toInt(), AMOUNT);
 
 	//check that the amount is changed when requested
 	shoppingList->setItemAmount(ITEM_3, AMOUNT*2);
-	QCOMPARE(shoppingList->data(shoppingList->index(2, 2)).toInt(), AMOUNT*2);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, ITEM_AMOUNT_COL)).toInt(), AMOUNT*2);
 }
 
 void ShoppingListTest::testDeleteItem()
@@ -82,12 +82,12 @@ void ShoppingListTest::testDeleteItem()
 	//check that correct row is deleted when using the item name
 	shoppingList->deleteItem(ITEM_2);
 	QCOMPARE(shoppingList->rowCount(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_1);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), ITEM_3);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), ITEM_1);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), ITEM_3);
 
 	//check that the correct row is deleted when using the row number
 	shoppingList->deleteItem(shoppingList->index(0, 0));
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_3);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), ITEM_3);
 }
 
 void ShoppingListTest::testWipeList()
@@ -97,7 +97,7 @@ void ShoppingListTest::testWipeList()
 	//verify that list is wiped
 	shoppingList->wipeList();
 	QCOMPARE(shoppingList->rowCount(), 0);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)), QVariant(QVariant::Invalid));
+	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)), QVariant(QVariant::Invalid));
 	shoppingList->wipeList();
 	QCOMPARE(shoppingList->rowCount(), 0);
 }
@@ -110,9 +110,9 @@ void ShoppingListTest::testDeleteLastItem()
 	//verify that last item was deleted
 	shoppingList->deleteLastAddedItem();
 	QCOMPARE(shoppingList->rowCount(), 3);
-	QCOMPARE(shoppingList->data(shoppingList->index(0, 0)).toString(), ITEM_1);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, 0)).toString(), ITEM_2);
-	QCOMPARE(shoppingList->data(shoppingList->index(2, 0)).toString(), ITEM_3);
+	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), ITEM_1);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), ITEM_2);
+	QCOMPARE(shoppingList->data(shoppingList->index(2, ITEM_NAME_COL)).toString(), ITEM_3);
 
 	//test deleteLastItem on empty list
 	delete shoppingList;

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -6,6 +6,8 @@
 void ShoppingListTest::init()
 {
 	shoppingList = new ShoppingList;
+
+	//TODO: Since all tests mostly use the same data, populate the shoppingList here.
 }
 
 void ShoppingListTest::cleanup()

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -48,7 +48,7 @@ void ShoppingListTest::testNewItem()
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), item_2);
 
 	//verify the other elements
-	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price*amount);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt(), amount);
 
 	//add item with same name, verify it doesn't overwrite the former item when price is different
@@ -56,13 +56,13 @@ void ShoppingListTest::testNewItem()
 	int amount_2 = 30;
 	shoppingList->newItem(item_2, price_2, amount_2);
 	QCOMPARE(shoppingList->numItems(), 2);
-	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble() != price_2);
+	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble() != price_2*amount_2);
 	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt() != amount_2);
 
 	//add item with same name, verify that it adds to the amount when the price is the same
 	shoppingList->newItem(item_2, price, amount_2);
 	QCOMPARE(shoppingList->numItems(), 2);
-	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price);
+	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price*(amount + amount_2));
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt(), amount + amount_2);
 }
 

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -109,7 +109,7 @@ void ShoppingListTest::testDeleteLastItem()
 	QCOMPARE(shoppingList->data(shoppingList->index(2, 0)).toString(), ITEM_3);
 }
 
-void ShoppingListTest::testGetTotalAmount()
+void ShoppingListTest::testGetTotalPrice()
 {
 	shoppingList->wipeList();
 	QCOMPARE(shoppingList->rowCount(), 0);
@@ -117,11 +117,11 @@ void ShoppingListTest::testGetTotalAmount()
 	int amount = 20;
 	double price = 20;
 	shoppingList->newItem(ITEM_1, price, amount);
-	QCOMPARE(shoppingList->getTotalAmount(), price*amount*1.0);
+	QCOMPARE(shoppingList->getTotalPrice(), price*amount*1.0);
 	shoppingList->newItem(ITEM_2, price, amount);
-	QCOMPARE(shoppingList->getTotalAmount(), 2*price*amount*1.0);
+	QCOMPARE(shoppingList->getTotalPrice(), 2*price*amount*1.0);
 	shoppingList->newItem(ITEM_3, price, amount);
-	QCOMPARE(shoppingList->getTotalAmount(), 3*price*amount*1.0);
+	QCOMPARE(shoppingList->getTotalPrice(), 3*price*amount*1.0);
 }
 
 QTEST_MAIN(ShoppingListTest)

--- a/tests/shoppinglist-t.cpp
+++ b/tests/shoppinglist-t.cpp
@@ -37,14 +37,14 @@ void ShoppingListTest::testNewItem()
 	int amount = 10;
 
 	//basic test of add
-	QCOMPARE(shoppingList->rowCount(), 0);
+	QCOMPARE(shoppingList->numItems(), 0);
 	shoppingList->newItem(item_1, price, amount);
 	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), item_1);
 
 	//add another item, verify it is added in a new row
-	QCOMPARE(shoppingList->rowCount(), 1);
+	QCOMPARE(shoppingList->numItems(), 1);
 	shoppingList->newItem(item_2, price, amount);
-	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->numItems(), 2);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), item_2);
 
 	//verify the other elements
@@ -55,13 +55,13 @@ void ShoppingListTest::testNewItem()
 	double price_2 = 30.0;
 	int amount_2 = 30;
 	shoppingList->newItem(item_2, price_2, amount_2);
-	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->numItems(), 2);
 	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble() != price_2);
 	QVERIFY(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt() != amount_2);
 
 	//add item with same name, verify that it adds to the amount when the price is the same
 	shoppingList->newItem(item_2, price, amount_2);
-	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->numItems(), 2);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_PRICE_COL)).toDouble(), price);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_AMOUNT_COL)).toInt(), amount + amount_2);
 }
@@ -77,11 +77,11 @@ void ShoppingListTest::testSetItemAmount()
 
 void ShoppingListTest::testDeleteItem()
 {
-	QCOMPARE(shoppingList->rowCount(), 3);
+	QCOMPARE(shoppingList->numItems(), 3);
 
 	//check that correct row is deleted when using the item name
 	shoppingList->deleteItem(ITEM_2);
-	QCOMPARE(shoppingList->rowCount(), 2);
+	QCOMPARE(shoppingList->numItems(), 2);
 	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), ITEM_1);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), ITEM_3);
 
@@ -92,24 +92,24 @@ void ShoppingListTest::testDeleteItem()
 
 void ShoppingListTest::testWipeList()
 {
-	QCOMPARE(shoppingList->rowCount(), 3);
+	QCOMPARE(shoppingList->numItems(), 3);
 
 	//verify that list is wiped
 	shoppingList->wipeList();
-	QCOMPARE(shoppingList->rowCount(), 0);
+	QCOMPARE(shoppingList->numItems(), 0);
 	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)), QVariant(QVariant::Invalid));
 	shoppingList->wipeList();
-	QCOMPARE(shoppingList->rowCount(), 0);
+	QCOMPARE(shoppingList->numItems(), 0);
 }
 
 void ShoppingListTest::testDeleteLastItem()
 {
 	shoppingList->newItem("something_different", 20, 20);
-	QCOMPARE(shoppingList->rowCount(), 4);
+	QCOMPARE(shoppingList->numItems(), 4);
 
 	//verify that last item was deleted
 	shoppingList->deleteLastAddedItem();
-	QCOMPARE(shoppingList->rowCount(), 3);
+	QCOMPARE(shoppingList->numItems(), 3);
 	QCOMPARE(shoppingList->data(shoppingList->index(0, ITEM_NAME_COL)).toString(), ITEM_1);
 	QCOMPARE(shoppingList->data(shoppingList->index(1, ITEM_NAME_COL)).toString(), ITEM_2);
 	QCOMPARE(shoppingList->data(shoppingList->index(2, ITEM_NAME_COL)).toString(), ITEM_3);
@@ -123,7 +123,7 @@ void ShoppingListTest::testDeleteLastItem()
 void ShoppingListTest::testGetTotalPrice()
 {
 	shoppingList->wipeList();
-	QCOMPARE(shoppingList->rowCount(), 0);
+	QCOMPARE(shoppingList->numItems(), 0);
 
 	int amount = 20;
 	double price = 20;

--- a/tests/shoppinglist-t.h
+++ b/tests/shoppinglist-t.h
@@ -6,15 +6,42 @@ class ShoppingList;
 class ShoppingListTest : public QObject {
 	Q_OBJECT
 	private slots:
+		/**
+		 * Create/clean up shopping list, populate shopping list with some default items.
+		 **/
 		void init();
 		void cleanup();
 
+		/**
+		 * Check that new item gets added, that new item with same name overwrites current item.
+		 **/
 		void testNewItem();
+
+		/**
+		 * Check that amount gets set.
+		 **/
 		void testSetItemAmount();
+
+		/**
+		 * Check that item is deleted.
+		 **/
 		void testDeleteItem();
+
+		/**
+		 * Check that items are wiped.
+		 **/
 		void testWipeList();
+
+		/**
+		 * Check that last item was deleted.
+		 **/
 		void testDeleteLastItem();
+
+		/**
+		 * Check that calculated total price is correct.
+		 **/
 		void testGetTotalPrice();
 	private:
+		///Shopping list
 		ShoppingList *shoppingList;
 };

--- a/tests/shoppinglist-t.h
+++ b/tests/shoppinglist-t.h
@@ -33,11 +33,6 @@ class ShoppingListTest : public QObject {
 		void testWipeList();
 
 		/**
-		 * Check that last item was deleted.
-		 **/
-		void testDeleteLastItem();
-
-		/**
 		 * Check that calculated total price is correct.
 		 **/
 		void testGetTotalPrice();

--- a/tests/shoppinglist-t.h
+++ b/tests/shoppinglist-t.h
@@ -14,7 +14,7 @@ class ShoppingListTest : public QObject {
 		void testDeleteItem();
 		void testWipeList();
 		void testDeleteLastItem();
-		void testGetTotalAmount();
+		void testGetTotalPrice();
 	private:
 		ShoppingList *shoppingList;
 };

--- a/tests/shoppinglist-t.h
+++ b/tests/shoppinglist-t.h
@@ -1,0 +1,10 @@
+class ShoppingListTest : QObject {
+	Q_OBJECT
+	private slots:
+		void testNewItem();
+		void testSetItemAmount();
+		void testDeleteItem();
+		void testWipeList();
+		void testDeleteLastItem();
+		void testGetTotalAmount();
+};

--- a/tests/shoppinglist-t.h
+++ b/tests/shoppinglist-t.h
@@ -1,10 +1,21 @@
-class ShoppingListTest : QObject {
+#include <QObject>
+#include <QtTest/QTest>
+
+class ShoppingList;
+class QTableView;
+
+class ShoppingListTest : public QObject {
 	Q_OBJECT
 	private slots:
+		void init();
+		void cleanup();
+
 		void testNewItem();
 		void testSetItemAmount();
 		void testDeleteItem();
 		void testWipeList();
 		void testDeleteLastItem();
 		void testGetTotalAmount();
+	private:
+		ShoppingList *shoppingList;
 };

--- a/tests/shoppinglist-t.h
+++ b/tests/shoppinglist-t.h
@@ -2,7 +2,6 @@
 #include <QtTest/QTest>
 
 class ShoppingList;
-class QTableView;
 
 class ShoppingListTest : public QObject {
 	Q_OBJECT


### PR DESCRIPTION
Note: Depends on changes made in #18. Pull request #18 might also become a bit confusing when not considering the changes here, so if you want, we could also merge this into the issue7-branch so that ShoppingList and ShoppingListWidget can be considered together.

Note 2: The changes listed in this PR will include also the changes listed in #18 until that one has been merged against master. The changes here can be reviewed isolated by clicking the correct buttons and making it compare against branch issue7 instead of master.

Description: Solves issue #8. Displays the `ShoppingList` developed in issue #7 in a QTableView, with a custom-developed QStyledItemDelegate-inheriting thing for drawing each table row a bit differently than standard. Everything is contained within `ShoppingListWidget`. Makes some changes to `ShoppingList` (the 'price'-column is now the total price for the item instead of the unit price, some column reordering) and removes unnecessary functions. 

Preview: 

![shoppinglist](https://cloud.githubusercontent.com/assets/1886244/19418846/daf6fe00-93cc-11e6-9355-a81e482fd64e.png)