### PR TITLE
Issue9

### DIFF
--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -18,7 +18,12 @@ void Daemon::processTransaction(QString card_number, QString amount, const QDBus
 	QList<QVariant> return_values;
 	return_values << QVariant(card_number);
 	return_values << QVariant(QString::number(-600));
-	return_values << QVariant(2);
+
+	if (card_number == QString("1234")) {
+		return_values << QVariant(0);
+	} else {
+		return_values << QVariant(2);
+	}
 	QDBusMessage reply = msg.createReply(return_values);
 	QDBusConnection::systemBus().send(reply);
 }

--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -3,6 +3,7 @@
 #include <QtDBus/QtDBus>
 #include <iostream>
 #include "daemon_common.h"
+#include <unistd.h>
 
 void Daemon::processTransaction(QString card_number, QString amount, const QDBusMessage &msg)
 {
@@ -13,6 +14,7 @@ void Daemon::processTransaction(QString card_number, QString amount, const QDBus
 	//TODO: Do real calls against backend API.
 
 	//TODO: Get result from transaction. Build feedback reply.
+	sleep(1); //FIXME: Remove when real backend calls are implemented. This is for simulating a delay in the daemon.
 
 	//prepare dummy reply: nickname, balance, transaction status
 	QList<QVariant> return_values;

--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -3,7 +3,10 @@
 #include <QtDBus/QtDBus>
 #include <iostream>
 #include "daemon_common.h"
+#include "daemon_client.h"
 #include <unistd.h>
+
+static double currentBalance = 400; //FIXME: Remove when real backend is implemented. Used for simulating a user account.
 
 void Daemon::processTransaction(QString card_number, QString amount, const QDBusMessage &msg)
 {
@@ -16,16 +19,26 @@ void Daemon::processTransaction(QString card_number, QString amount, const QDBus
 	//TODO: Get result from transaction. Build feedback reply.
 	sleep(1); //FIXME: Remove when real backend calls are implemented. This is for simulating a delay in the daemon.
 
-	//prepare dummy reply: nickname, balance, transaction status
-	QList<QVariant> return_values;
-	return_values << QVariant("tjafsus");
-	return_values << QVariant(QString::number(-600));
+	//prepare dummy reply
+	QString username = "Ragno";
+	double newBalance = std::nan("");
+	int transactionStatus = (int)DaemonClient::TRANSACTION_SUCCESSFUL;
 
-	if (card_number == QString("1234")) {
-		return_values << QVariant(0);
+	if (card_number == QString("1234")) { //"accept" transactions when card number is 1234
+		if (currentBalance < 0) { //simulate that ufs has blacklisted the user
+			newBalance = currentBalance;
+			transactionStatus = (int)DaemonClient::USER_BLACKLISTED;
+		} else {
+			currentBalance -= amount.toDouble();
+			newBalance = currentBalance;
+		}
 	} else {
-		return_values << QVariant(2);
+		transactionStatus = (int)DaemonClient::USER_NOT_IN_LOCAL_DATABASE;
 	}
+
+	//construct reply: nickname, balance, transaction status
+	QList<QVariant> return_values;
+	return_values << QVariant(username) << QVariant(QString::number(newBalance)) << QVariant(transactionStatus);
 	QDBusMessage reply = msg.createReply(return_values);
 	QDBusConnection::systemBus().send(reply);
 }

--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -20,11 +20,12 @@ void Daemon::processTransaction(QString card_number, QString amount, const QDBus
 	sleep(1); //FIXME: Remove when real backend calls are implemented. This is for simulating a delay in the daemon.
 
 	//prepare dummy reply
-	QString username = "Ragno";
-	double newBalance = std::nan("");
+	QString username = UNKNOWN_USER;
+	double newBalance = UNKNOWN_BALANCE;
 	int transactionStatus = (int)DaemonClient::TRANSACTION_SUCCESSFUL;
 
 	if (card_number == QString("1234")) { //"accept" transactions when card number is 1234
+		username = "Ragno";
 		if (currentBalance < 0) { //simulate that ufs has blacklisted the user
 			newBalance = currentBalance;
 			transactionStatus = (int)DaemonClient::USER_BLACKLISTED;

--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -16,7 +16,7 @@ void Daemon::processTransaction(QString card_number, QString amount, const QDBus
 
 	//prepare dummy reply: nickname, balance, transaction status
 	QList<QVariant> return_values;
-	return_values << QVariant(card_number);
+	return_values << QVariant("tjafsus");
 	return_values << QVariant(QString::number(-600));
 
 	if (card_number == QString("1234")) {

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -11,7 +11,7 @@ class Daemon : public QObject {
 	public slots:
 		/**
 		 * Receive request for transaction from GUI application.
-		 * Returns with card number, current balance and transaction
+		 * Returns with username, current balance and transaction
 		 * status when finished. (QString, QString, int)
 		 *
 		 * \param card_number Card number

--- a/daemon/daemon_common.h
+++ b/daemon/daemon_common.h
@@ -1,1 +1,5 @@
-#define DBUS_SERVICE_NAME "org.digcross.daemonconnection"
+#include <cmath>
+
+const QString DBUS_SERVICE_NAME = "org.digcross.daemonconnection";
+const QString UNKNOWN_USER = "UNKNOWN_USER";
+const double UNKNOWN_BALANCE = std::nan("");

--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -2,6 +2,7 @@
 
 #include <QEvent>
 #include <QKeyEvent>
+#include <QApplication>
 
 bool CardReader::eventFilter(QObject *object, QEvent *event)
 {
@@ -29,4 +30,14 @@ bool CardReader::eventFilter(QObject *object, QEvent *event)
 	}
 
 	return true;
+}
+
+void CardReader::enable()
+{
+	qApp->installEventFilter(this);
+}
+
+void CardReader::disable()
+{
+	qApp->removeEventFilter(this);
 }

--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -20,8 +20,9 @@ bool CardReader::eventFilter(QObject *object, QEvent *event)
 	//send signal on enter (RFID card reader ends string input with an enter)
 	if (keyEvent->key() == Qt::Key_Return) {
 		//disallow entries with duration less than a time limit in order to avoid keyboard input and allow only the fast RFID reader
-		if (writeTime.elapsed() < CARDREADER_TIME_LIMIT_MS) {
-			emit newCardNumber(cardNumber.simplified());
+		cardNumber = cardNumber.simplified();
+		if ((writeTime.elapsed() < CARDREADER_TIME_LIMIT_MS) && (!cardNumber.isEmpty())) {
+			emit newCardNumber(cardNumber);
 		}
 
 		cardNumber.clear();

--- a/src/cardreader.h
+++ b/src/cardreader.h
@@ -12,12 +12,24 @@ const int CARDREADER_TIME_LIMIT_MS = 100000;
 /**
  * Receives input from RFID card reader. Accumulates characters in a buffer and
  * emits a signal when card number is ready. (Receives keyboard characters,
- * send signal on \n.) Must be installed as an event filter in a widget.
+ * send signal on \n.) Blocks all keyboard input.
+ *
+ * Enable by using enable(), disable keyboard filtering using disable(). Enabled by default.
  **/
 class CardReader : public QObject {
 	Q_OBJECT
 	public:
-		CardReader(QObject *parent = NULL){};
+		CardReader(QObject *parent = NULL){enable();};
+
+		/**
+		 * Enable card reader input and block all keyboard input to all other widgets.
+		 **/
+		void enable();
+
+		/**
+		 * Disable card reader input and enable keyboard input to other widgets.
+		 **/
+		void disable();
 	signals:
 		/**
 		 * New card number has been received from RFID reader.

--- a/src/cardreader.h
+++ b/src/cardreader.h
@@ -7,7 +7,7 @@
 class QEvent;
 
 ///Allowed time for card reader to read input characters, in order to avoid normal keyboard input and only allow a fast RFID reader
-const int CARDREADER_TIME_LIMIT_MS = 100000;
+const int CARDREADER_TIME_LIMIT_MS = 100;
 
 /**
  * Receives input from RFID card reader. Accumulates characters in a buffer and

--- a/src/cardreader.h
+++ b/src/cardreader.h
@@ -7,7 +7,7 @@
 class QEvent;
 
 ///Allowed time for card reader to read input characters, in order to avoid normal keyboard input and only allow a fast RFID reader
-const int CARDREADER_TIME_LIMIT_MS = 100;
+const int CARDREADER_TIME_LIMIT_MS = 100000;
 
 /**
  * Receives input from RFID card reader. Accumulates characters in a buffer and

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -7,7 +7,7 @@
 
 DaemonClient::DaemonClient(QObject *parent) : QObject(parent)
 {
-	qRegisterMetaType<DaemonClient::TransactionStatus>("TransactionStatus");
+	qRegisterMetaType<DaemonClient::TransactionStatus>("DaemonClient::TransactionStatus");
 }
 
 void DaemonClient::processTransaction(QString card_number, float amount)

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -38,3 +38,19 @@ void DaemonClient::transactionFinished(QDBusPendingCallWatcher *call)
 
 	call->deleteLater();
 }
+
+QString DaemonClient::errorMessage(TransactionStatus status)
+{
+	switch (status) {
+		case TRANSACTION_SUCCESSFUL:
+			return QString();
+		case USER_BLACKLISTED:
+			return QString(tr("User is blacklisted."));
+		case USER_NOT_IN_UFS_DATABASE:
+			return QString(tr("User was not found in ufs database."));
+		case USER_NOT_IN_LOCAL_DATABASE:
+			return QString(tr("Card number was not found in local database."));
+		case UFS_UNAVAILABLE:
+			return QString(tr("Could not contact ufs."));
+	}
+}

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -30,11 +30,11 @@ void DaemonClient::transactionFinished(QDBusPendingCallWatcher *call)
 	}
 
 	//parse returned values and emit result
-	QString card_number = reply.argumentAt(0).toString();
+	QString username = reply.argumentAt(0).toString();
 	QString balance = reply.argumentAt(1).toString();
 	TransactionStatus status = (TransactionStatus)reply.argumentAt(2).toInt();
 
-	emit transactionFeedback(card_number, balance.toFloat(), status);
+	emit transactionFeedback(username, balance.toFloat(), status);
 
 	call->deleteLater();
 }

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -45,11 +45,11 @@ QString DaemonClient::errorMessage(TransactionStatus status)
 		case TRANSACTION_SUCCESSFUL:
 			return QString();
 		case USER_BLACKLISTED:
-			return QString(tr("User is blacklisted."));
+			return QString(tr("User was blacklisted."));
 		case USER_NOT_IN_UFS_DATABASE:
 			return QString(tr("User was not found in ufs database."));
 		case USER_NOT_IN_LOCAL_DATABASE:
-			return QString(tr("Card number was not found in local database."));
+			return QString(tr("Card was not found in local database."));
 		case UFS_UNAVAILABLE:
 			return QString(tr("Could not contact ufs."));
 	}

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -22,19 +22,24 @@ void DaemonClient::processTransaction(QString card_number, float amount)
 
 void DaemonClient::transactionFinished(QDBusPendingCallWatcher *call)
 {
+	TransactionStatus status;
+	QString username;
+	double balance;
+
 	QDBusPendingReply<QString, QString, int> reply = call->reply();
 
 	if (!reply.isValid()) {
-		emit dbusError(reply.error().message());
-		return;
+		username = UNKNOWN_USER;
+		balance = UNKNOWN_BALANCE;
+		status = DBUS_ERROR;
+	} else {
+		//parse returned values and emit result
+		username = reply.argumentAt(0).toString();
+		balance = reply.argumentAt(1).toString().toFloat();
+		status = (TransactionStatus)reply.argumentAt(2).toInt();
 	}
 
-	//parse returned values and emit result
-	QString username = reply.argumentAt(0).toString();
-	QString balance = reply.argumentAt(1).toString();
-	TransactionStatus status = (TransactionStatus)reply.argumentAt(2).toInt();
-
-	emit transactionFeedback(username, balance.toFloat(), status);
+	emit transactionFeedback(username, balance, status);
 
 	call->deleteLater();
 }
@@ -52,5 +57,7 @@ QString DaemonClient::errorMessage(TransactionStatus status)
 			return QString(tr("Card was not found in local database."));
 		case UFS_UNAVAILABLE:
 			return QString(tr("Could not contact ufs."));
+		case DBUS_ERROR:
+			return QString(tr("Could not contact transaction daemon."));
 	}
 }

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -45,7 +45,7 @@ QString DaemonClient::errorMessage(TransactionStatus status)
 		case TRANSACTION_SUCCESSFUL:
 			return QString();
 		case USER_BLACKLISTED:
-			return QString(tr("User was blacklisted."));
+			return QString(tr("User is blacklisted."));
 		case USER_NOT_IN_UFS_DATABASE:
 			return QString(tr("User was not found in ufs database."));
 		case USER_NOT_IN_LOCAL_DATABASE:

--- a/src/daemon_client.cpp
+++ b/src/daemon_client.cpp
@@ -7,7 +7,7 @@
 
 DaemonClient::DaemonClient(QObject *parent) : QObject(parent)
 {
-	qRegisterMetaType<TransactionStatus>("TransactionStatus");
+	qRegisterMetaType<DaemonClient::TransactionStatus>("TransactionStatus");
 }
 
 void DaemonClient::processTransaction(QString card_number, float amount)

--- a/src/daemon_client.h
+++ b/src/daemon_client.h
@@ -11,7 +11,6 @@
  *
  * - To process a transaction, call processTransaction() on a given card number and amount to process.
  * - To receive a result from this transaction, connect transactionFeedback() to a suitable SLOT.
- * - DBus-related errors are signaled through dbusError().
  **/
 class DaemonClient : public QObject {
 	Q_OBJECT
@@ -23,7 +22,8 @@ class DaemonClient : public QObject {
 				       USER_BLACKLISTED,
 				       USER_NOT_IN_UFS_DATABASE,
 				       USER_NOT_IN_LOCAL_DATABASE,
-				       UFS_UNAVAILABLE};
+				       UFS_UNAVAILABLE,
+				       DBUS_ERROR};
 
 		DaemonClient(QObject *parent = NULL);
 
@@ -47,13 +47,6 @@ class DaemonClient : public QObject {
 		 * \param status Status of transaction
 		 **/
 		void transactionFeedback(QString username, float newBalance, DaemonClient::TransactionStatus status);
-
-		/**
-		 * Signalled on DBus errors.
-		 *
-		 * \param errorMessage Error message
-		 **/
-		void dbusError(QString errorMessage);
 	private slots:
 		/**
 		 * For catching internal signal when daemon is finished with

--- a/src/daemon_client.h
+++ b/src/daemon_client.h
@@ -44,7 +44,7 @@ class DaemonClient : public QObject {
 		 * \param newBalance New balance for user after transaction
 		 * \param status Status of transaction
 		 **/
-		void transactionFeedback(QString card_number, float newBalance, TransactionStatus status);
+		void transactionFeedback(QString card_number, float newBalance, DaemonClient::TransactionStatus status);
 
 		/**
 		 * Signalled on DBus errors.

--- a/src/daemon_client.h
+++ b/src/daemon_client.h
@@ -42,11 +42,11 @@ class DaemonClient : public QObject {
 		 * the daemon. By design, we restrict database information to
 		 * the information defined here.
 		 *
-		 * \param card_number Card number for which transaction was processed
+		 * \param username Username for which transaction was processed
 		 * \param newBalance New balance for user after transaction
 		 * \param status Status of transaction
 		 **/
-		void transactionFeedback(QString card_number, float newBalance, DaemonClient::TransactionStatus status);
+		void transactionFeedback(QString username, float newBalance, DaemonClient::TransactionStatus status);
 
 		/**
 		 * Signalled on DBus errors.

--- a/src/daemon_client.h
+++ b/src/daemon_client.h
@@ -26,6 +26,8 @@ class DaemonClient : public QObject {
 				       UFS_UNAVAILABLE};
 
 		DaemonClient(QObject *parent = NULL);
+
+		static QString errorMessage(TransactionStatus status);
 	public slots:
 		/**
 		 * Attempt to process transaction for a card number and amount.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -64,7 +64,7 @@ void MainWindow::triggerTransaction(QString cardNumber)
 
 		//send transaction
 		double totalPrice = shoppingList->getTotalPrice();
-		statusBar->setPermanentMessage(tr("Waiting for transaction..."));
+		statusBar->setPersistentMessage(tr("Waiting for transaction..."));
 		transactionDaemon->processTransaction(cardNumber, totalPrice);
 	}
 }
@@ -75,7 +75,7 @@ void MainWindow::transactionFinished(QString username, float newBalance, DaemonC
 	if (status == DaemonClient::TRANSACTION_SUCCESSFUL) {
 		double price = shoppingList->getTotalPrice();
 		shoppingList->wipeList();
-		statusBar->setPermanentMessage(tr("Last transaction: ") + QString::number(price) + " kr for " + username);
+		statusBar->setPersistentMessage(tr("Last transaction: ") + QString::number(price) + " kr for " + username);
 		statusBar->setTemporaryMessage(tr("Transaction processed. New balance for ") + username + ": kr " + QString::number(newBalance), StatusBar::SUCCESS_ICON);
 	} else {
 		updateDisplayPrice();
@@ -92,9 +92,9 @@ void MainWindow::updateDisplayPrice()
 	double currPrice = shoppingList->getTotalPrice();
 
 	if (currPrice > 0) {
-		statusBar->setPermanentMessage(tr("Swipe a card to process the following sum: ") + QString::number(currPrice) + " kr");
+		statusBar->setPersistentMessage(tr("Swipe a card to process the following sum: ") + QString::number(currPrice) + " kr");
 	} else {
-		statusBar->clearPermanentMessage();
+		statusBar->clearPersistentMessage();
 	}
 }
 
@@ -141,24 +141,29 @@ void StatusBar::clearTemporaryMessage()
 	icon->clear();
 	timer->stop();
 
-	//revert to permanent message
-	if (permanentMessage.size() > 0) {
-		text->setText(permanentMessage);
+	//revert to persistent message
+	if (persistentMessage.size() > 0) {
+		text->setText(persistentMessage);
 	}
 }
 
-void StatusBar::setPermanentMessage(QString message)
+void StatusBar::setPersistentMessage(QString message)
 {
-	permanentMessage = message;
+	persistentMessage = message;
 
 	clearTemporaryMessage();
 }
 
-void StatusBar::clearPermanentMessage()
+void StatusBar::clearPersistentMessage()
 {
-	permanentMessage = QString();
+	persistentMessage = QString();
 
 	if (!timer->isActive()) {
 		clearTemporaryMessage();
 	}
+}
+
+QString StatusBar::currentMessage()
+{
+	return text->text();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -79,7 +79,7 @@ void MainWindow::transactionFinished(QString username, float newBalance, DaemonC
 		statusBar->setTemporaryMessage(tr("Transaction processed. New balance for ") + username + ": kr " + QString::number(newBalance), StatusBar::SUCCESS_ICON);
 	} else {
 		updateDisplayPrice();
-		statusBar->setTemporaryMessage(DaemonClient::errorMessage(status), StatusBar::ERROR_ICON);
+		statusBar->setTemporaryMessage(tr("Transaction denied. ") + DaemonClient::errorMessage(status), StatusBar::ERROR_ICON);
 	}
 
 	//re-enable input

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -54,7 +54,7 @@ void MainWindow::triggerTransaction(QString cardNumber)
 	}
 }
 
-void MainWindow::receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status)
+void MainWindow::receiveTransactionFeedback(QString username, float newBalance, DaemonClient::TransactionStatus status)
 {
 	if (status == DaemonClient::TRANSACTION_SUCCESSFUL) {
 		statusBar->showMessage(tr("Transaction processed. New balance: kr ") + QString::number(newBalance), StatusBar::SUCCESS_ICON);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -162,8 +162,3 @@ void StatusBar::clearPersistentMessage()
 		clearTemporaryMessage();
 	}
 }
-
-QString StatusBar::currentMessage()
-{
-	return text->text();
-}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -57,7 +57,7 @@ void MainWindow::triggerTransaction(QString cardNumber)
 void MainWindow::receiveTransactionFeedback(QString username, float newBalance, DaemonClient::TransactionStatus status)
 {
 	if (status == DaemonClient::TRANSACTION_SUCCESSFUL) {
-		statusBar->showMessage(tr("Transaction processed. New balance: kr ") + QString::number(newBalance), StatusBar::SUCCESS_ICON);
+		statusBar->showMessage(tr("Transaction processed. New balance for ") + username + ": kr " + QString::number(newBalance), StatusBar::SUCCESS_ICON);
 		shoppingList->wipeList();
 	} else {
 		statusBar->showMessage(DaemonClient::errorMessage(status), StatusBar::ERROR_ICON);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4,7 +4,6 @@
 
 #include <QGridLayout>
 #include <QLabel>
-#include <QApplication>
 #include <QMessageBox>
 #include <QPushButton>
 
@@ -19,7 +18,6 @@ MainWindow::MainWindow(QWidget *parent)
 	//install cardReader as an filter which intercepts _all_ keyboard events to the application
 	cardReader = new CardReader(this);
 	connect(cardReader, SIGNAL(newCardNumber(QString)), SLOT(triggerTransaction(QString)));
-	enableCardReader(true);
 
 	//shoppinglist and associated view
 	shoppingList = new ShoppingList(this);
@@ -62,7 +60,7 @@ void MainWindow::receiveTransactionFeedback(QString cardNumber, float newBalance
 
 void MainWindow::showMessage(bool success, QString message)
 {
-	enableCardReader(false);
+	cardReader->disable();
 
 	//FIXME: This should display the result in the MainWindow widget itself
 	//instead of a separate message box.
@@ -73,14 +71,5 @@ void MainWindow::showMessage(bool success, QString message)
 		QMessageBox::information(this, title, message);
 	}
 
-	enableCardReader(true);
-}
-
-void MainWindow::enableCardReader(bool on)
-{
-	if (on) {
-		qApp->installEventFilter(cardReader);
-	} else {
-		qApp->removeEventFilter(cardReader);
-	}
+	cardReader->enable();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -58,9 +58,12 @@ void MainWindow::addTestItems()
 void MainWindow::triggerTransaction(QString cardNumber)
 {
 	if (shoppingList->numItems() > 0) {
+		//disable input
 		this->setEnabled(false);
-		double totalPrice = shoppingList->getTotalPrice();
 		cardReader->disable();
+
+		//send transaction
+		double totalPrice = shoppingList->getTotalPrice();
 		statusBar->setPermanentMessage(tr("Waiting for transaction..."));
 		transactionDaemon->processTransaction(cardNumber, totalPrice);
 	}
@@ -68,6 +71,7 @@ void MainWindow::triggerTransaction(QString cardNumber)
 
 void MainWindow::transactionFinished(QString username, float newBalance, DaemonClient::TransactionStatus status)
 {
+	//display appropriate status messages for result of transaction
 	if (status == DaemonClient::TRANSACTION_SUCCESSFUL) {
 		double price = shoppingList->getTotalPrice();
 		shoppingList->wipeList();
@@ -77,6 +81,8 @@ void MainWindow::transactionFinished(QString username, float newBalance, DaemonC
 		updateDisplayPrice();
 		statusBar->setTemporaryMessage(DaemonClient::errorMessage(status), StatusBar::ERROR_ICON);
 	}
+
+	//re-enable input
 	this->setEnabled(true);
 	cardReader->enable();
 }
@@ -135,6 +141,7 @@ void StatusBar::clearTemporaryMessage()
 	icon->clear();
 	timer->stop();
 
+	//revert to permanent message
 	if (permanentMessage.size() > 0) {
 		text->setText(permanentMessage);
 	}
@@ -150,6 +157,7 @@ void StatusBar::setPermanentMessage(QString message)
 void StatusBar::clearPermanentMessage()
 {
 	permanentMessage = QString();
+
 	if (!timer->isActive()) {
 		clearTemporaryMessage();
 	}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,32 +1,48 @@
 #include "mainwindow.h"
 #include "cardreader.h"
+#include "shoppinglist.h"
 
 #include <QGridLayout>
 #include <QLabel>
-
-#include "shoppinglist.h"
+#include <QApplication>
 
 MainWindow::MainWindow(QWidget *parent)
 {
 	QGridLayout *layout = new QGridLayout(this);
-	QLabel *testLabel = new QLabel;
-	layout->addWidget(testLabel);
 
-	//install cardReader as an filter which intercepts keyboard events
+	//install cardReader as an filter which intercepts _all_ keyboard events to the application
 	CardReader *cardReader = new CardReader(this);
-	installEventFilter(cardReader);
-	connect(cardReader, SIGNAL(newCardNumber(QString)), testLabel, SLOT(setText(QString)));
+	qApp->installEventFilter(cardReader);
+	connect(cardReader, SIGNAL(newCardNumber(QString)), SLOT(triggerTransaction(QString)));
 
 	//shoppinglist and associated view
-	ShoppingList *list = new ShoppingList(this);
+	shoppingList = new ShoppingList(this);
 
-	ShoppingListWidget *shoppingListWidget = new ShoppingListWidget(list);
+	ShoppingListWidget *shoppingListWidget = new ShoppingListWidget(shoppingList);
 	layout->addWidget(shoppingListWidget);
 
 	//Populate with some example data.
 	//Menu class will have to connect to ShoppingList::newItem().
-	list->newItem("Brus", 15, 2);
-	list->newItem("Godterisopp", 2, 35);
-	list->newItem("Kvikklunsj", 10, 1);
-	list->newItem("Ragni spesial", 788.5, 3);
+	shoppingList->newItem("Brus", 15, 2);
+	shoppingList->newItem("Godterisopp", 2, 35);
+	shoppingList->newItem("Kvikklunsj", 10, 1);
+	shoppingList->newItem("Ragni spesial", 788.5, 3);
+
+	//daemon client
+	transactionDaemon = new DaemonClient(this);
+	connect(transactionDaemon, SIGNAL(transactionFeedback(QString, float, DaemonClient::TransactionStatus)), SLOT(receiveTransactionFeedback(QString, float, DaemonClient::TransactionStatus)));
+}
+
+void MainWindow::triggerTransaction(QString cardNumber)
+{
+	if (shoppingList->numItems() > 0) {
+		this->setEnabled(false);
+		double totalPrice = shoppingList->getTotalPrice();
+		transactionDaemon->processTransaction(cardNumber, totalPrice);
+	}
+}
+
+void MainWindow::receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status)
+{
+	//this->setEnabled(true);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,7 +39,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 	//status message widget
 	statusBar = new StatusBar;
-	layout->addWidget(statusBar, ++row, col, 1, num_cols);
+	layout->addWidget(statusBar, ++row, col);
 
 	//wipe button for shopping list
 	QPushButton *wipeButton = new QPushButton(qApp->style()->standardIcon(QStyle::SP_DialogResetButton), tr("Wipe list"));
@@ -101,7 +101,11 @@ void MainWindow::updateDisplayPrice()
 StatusBar::StatusBar(QObject *parent)
 {
 	QHBoxLayout *layout = new QHBoxLayout(this);
+	layout->setSizeConstraint(QLayout::SetMinimumSize);
+
 	text = new QLabel;
+	text->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+	text->setWordWrap(true);
 	icon = new QLabel;
 	timer = new QTimer(this);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,8 @@ void MainWindow::triggerTransaction(QString cardNumber)
 	if (shoppingList->numItems() > 0) {
 		this->setEnabled(false);
 		double totalPrice = shoppingList->getTotalPrice();
+		cardReader->disable();
+		statusBar->setPermanentMessage(tr("Waiting for transaction..."));
 		transactionDaemon->processTransaction(cardNumber, totalPrice);
 	}
 }
@@ -61,9 +63,11 @@ void MainWindow::receiveTransactionFeedback(QString username, float newBalance, 
 		statusBar->setTemporaryMessage(tr("Transaction processed. New balance for ") + username + ": kr " + QString::number(newBalance), StatusBar::SUCCESS_ICON);
 		shoppingList->wipeList();
 	} else {
+		updateDisplayPrice();
 		statusBar->setTemporaryMessage(DaemonClient::errorMessage(status), StatusBar::ERROR_ICON);
 	}
 	this->setEnabled(true);
+	cardReader->enable();
 }
 
 void MainWindow::updateDisplayPrice()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -22,4 +22,5 @@ class MainWindow : public QWidget {
 		void receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status);
 		void enableCardReader(bool on);
 		void showMessage(bool success, QString message);
+		void addTestItems();
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,7 +59,7 @@ const int STATUSBAR_TIMEOUT_MS = 5000;
 
 /**
  * Status bar, displays messages to the user with an optional icon on the left side.
- * Can display temporary messages which revert to a permanent message after a given time.
+ * Can display temporary messages which revert to a persistent message after a given time.
  *
  * (Similar to QStatusBar, but with customized features.)
  **/
@@ -67,6 +67,13 @@ class StatusBar : public QWidget {
 	Q_OBJECT
 	public:
 		StatusBar(QObject *parent = NULL);
+
+		/**
+		 * Get currently displayed status message.
+		 *
+		 * \return Current status message
+		 **/
+		QString currentMessage();
 
 		/**
 		 * Icon to display in status bar.
@@ -79,8 +86,8 @@ class StatusBar : public QWidget {
 	public slots:
 		/**
 		 * Display temporary message on statusbar together with an optional icon.
-		 * If a permanent message has been set, the status bar will revert to
-		 * the permanent message after the timeout (otherwise set the status bar empty).
+		 * If a persistent message has been set, the status bar will revert to
+		 * the persistent message after the timeout (otherwise set the status bar empty).
 		 *
 		 * \param message Message to display
 		 * \param icon Icon to display
@@ -89,24 +96,24 @@ class StatusBar : public QWidget {
 		void setTemporaryMessage(QString message, StatusIcon icon = NO_ICON, int timeout = STATUSBAR_TIMEOUT_MS);
 
 		/**
-		 * Set a permanent message on the status bar. Any temporary messages will immediately
-		 * be cleared. Temporary messages will overwrite the permanent message, but the status bar
-		 * reverts to the permanent message after the timeout.
+		 * Set a persistent message on the status bar. Any temporary messages will immediately
+		 * be cleared. Temporary messages will overwrite the persistent message, but the status bar
+		 * reverts to the persistent message after the timeout.
 		 **/
-		void setPermanentMessage(QString message);
+		void setPersistentMessage(QString message);
 
 		/**
-		 * Clear temporary message from status bar, revert to permanent message (or empty status bar).
+		 * Clear temporary message from status bar, revert to persistent message (or empty status bar).
 		 **/
 		void clearTemporaryMessage();
 
 		/**
-		 * Clear permanent message from status bar, but not temporary messages that are still being displayed.
+		 * Clear persistent message from status bar, but not temporary messages that are still being displayed.
 		 **/
-		void clearPermanentMessage();
+		void clearPersistentMessage();
 	private:
 		///Message the status bar will revert to when the temporary message is cleared
-		QString permanentMessage;
+		QString persistentMessage;
 		///Status text
 		QLabel *text;
 		///Status icon

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,23 +25,26 @@ class MainWindow : public QWidget {
 		StatusBar *statusBar;
 	private slots:
 		/**
-		 * Start a transaction. Calculates amount to transact from shoppingList.
+		 * Start a transaction. Calculates amount to transact from shoppingList, sends to daemon client. Locks the GUI and the
+		 * card reader.
 		 *
 		 * \param cardNumber Card number
 		 **/
 		void triggerTransaction(QString cardNumber);
 
 		/**
-		 * Receive transaction feedback signal from DaemonClient.
+		 * Receive transaction feedback signal from DaemonClient. Unlocks GUI and the card reader.
 		 *
 		 * \param username Username for which transaction was attempted processed
 		 * \param newBalance New balance of user
 		 * \param status Transaction status
 		 **/
-		void receiveTransactionFeedback(QString username, float newBalance, DaemonClient::TransactionStatus status);
+		void transactionFinished(QString username, float newBalance, DaemonClient::TransactionStatus status);
 
 		/**
 		 * Add a couple of test items to the shopping list.
+		 *
+		 * FIXME: Remove when main menu has been implemented.
 		 **/
 		void addTestItems();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -69,13 +69,6 @@ class StatusBar : public QWidget {
 		StatusBar(QObject *parent = NULL);
 
 		/**
-		 * Get currently displayed status message.
-		 *
-		 * \return Current status message
-		 **/
-		QString currentMessage();
-
-		/**
 		 * Icon to display in status bar.
 		 **/
 		enum StatusIcon {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -2,6 +2,7 @@
 #include "daemon_client.h"
 
 class ShoppingList;
+class CardReader;
 
 /**
  * Mainwindow container widget opened when starting digcross.
@@ -15,7 +16,10 @@ class MainWindow : public QWidget {
 		ShoppingList *shoppingList;
 		///Client interface against transaction daemon
 		DaemonClient *transactionDaemon;
+		CardReader *cardReader;
 	private slots:
 		void triggerTransaction(QString cardNumber);
 		void receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status);
+		void enableCardReader(bool on);
+		void showMessage(bool success, QString message);
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -5,6 +5,45 @@ class ShoppingList;
 class CardReader;
 class QStatusBar;
 class QLabel;
+class StatusBar;
+
+/**
+ * Mainwindow container widget opened when starting digcross.
+ **/
+class MainWindow : public QWidget {
+	Q_OBJECT
+	public:
+		MainWindow(QWidget *parent = NULL);
+	private:
+		///List over items the user wants to buy
+		ShoppingList *shoppingList;
+		///Client interface against transaction daemon
+		DaemonClient *transactionDaemon;
+		///Card reader
+		CardReader *cardReader;
+		StatusBar *statusBar;
+	private slots:
+		/**
+		 * Start a transaction. Calculates amount to transact from shoppingList.
+		 *
+		 * \param cardNumber Card number
+		 **/
+		void triggerTransaction(QString cardNumber);
+
+		/**
+		 * Receive transaction feedback signal from DaemonClient.
+		 *
+		 * \param username Username for which transaction was attempted processed
+		 * \param newBalance New balance of user
+		 * \param status Transaction status
+		 **/
+		void receiveTransactionFeedback(QString username, float newBalance, DaemonClient::TransactionStatus status);
+
+		/**
+		 * Add a couple of test items to the shopping list.
+		 **/
+		void addTestItems();
+};
 
 ///Default timeout of status bar messages
 const int STATUSBAR_TIMEOUT_MS = 5000;
@@ -47,42 +86,4 @@ class StatusBar : public QWidget {
 		///Timer for clearing the status bar
 		QTimer *timer;
 
-};
-
-/**
- * Mainwindow container widget opened when starting digcross.
- **/
-class MainWindow : public QWidget {
-	Q_OBJECT
-	public:
-		MainWindow(QWidget *parent = NULL);
-	private:
-		///List over items the user wants to buy
-		ShoppingList *shoppingList;
-		///Client interface against transaction daemon
-		DaemonClient *transactionDaemon;
-		///Card reader
-		CardReader *cardReader;
-		StatusBar *statusBar;
-	private slots:
-		/**
-		 * Start a transaction. Calculates amount to transact from shoppingList.
-		 *
-		 * \param cardNumber Card number
-		 **/
-		void triggerTransaction(QString cardNumber);
-
-		/**
-		 * Receive transaction feedback signal from DaemonClient.
-		 *
-		 * \param cardNumber Cardnumber for which transaction was attempted processed
-		 * \param newBalance New balance of user
-		 * \param status Transaction status
-		 **/
-		void receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status);
-
-		/**
-		 * Add a couple of test items to the shopping list.
-		 **/
-		void addTestItems();
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,4 +1,5 @@
 #include <QWidget>
+#include "daemon_client.h"
 
 class ShoppingList;
 
@@ -10,5 +11,11 @@ class MainWindow : public QWidget {
 	public:
 		MainWindow(QWidget *parent = NULL);
 	private:
+		///List over items the user wants to buy
 		ShoppingList *shoppingList;
+		///Client interface against transaction daemon
+		DaemonClient *transactionDaemon;
+	private slots:
+		void triggerTransaction(QString cardNumber);
+		void receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status);
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -16,11 +16,35 @@ class MainWindow : public QWidget {
 		ShoppingList *shoppingList;
 		///Client interface against transaction daemon
 		DaemonClient *transactionDaemon;
+		///Card reader
 		CardReader *cardReader;
 	private slots:
+		/**
+		 * Start a transaction. Calculates amount to transact from shoppingList.
+		 *
+		 * \param cardNumber Card number
+		 **/
 		void triggerTransaction(QString cardNumber);
+
+		/**
+		 * Receive transaction feedback signal from DaemonClient.
+		 *
+		 * \param cardNumber Cardnumber for which transaction was attempted processed
+		 * \param newBalance New balance of user
+		 * \param status Transaction status
+		 **/
 		void receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status);
-		void enableCardReader(bool on);
+
+		/**
+		 * Show message in MainWindow. Displays appropriate icons based on the success variable.
+		 *
+		 * \param success Whether action calling this function was a success or not
+		 * \param message Message to display
+		 **/
 		void showMessage(bool success, QString message);
+
+		/**
+		 * Add a couple of test items to the shopping list.
+		 **/
 		void addTestItems();
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,51 @@
 
 class ShoppingList;
 class CardReader;
+class QStatusBar;
+class QLabel;
+
+///Default timeout of status bar messages
+const int STATUSBAR_TIMEOUT_MS = 5000;
+
+/**
+ * Status bar. More or less like QStatusBar, but with an icon on the right side.
+ **/
+class StatusBar : public QWidget {
+	Q_OBJECT
+	public:
+		StatusBar(QObject *parent = NULL);
+
+		/**
+		 * Icon to display in status bar.
+		 **/
+		enum StatusIcon {
+			NO_ICON, //no icon
+			ERROR_ICON, //display an error icon
+			SUCCESS_ICON //display a green checkmark
+		};
+	public slots:
+		/**
+		 * Display message on statusbar together with an optional icon.
+		 *
+		 * \param message Message to display
+		 * \param icon Icon to display
+		 * \param timeout Timeout value of message
+		 **/
+		void showMessage(QString message, StatusIcon icon = NO_ICON, int timeout = STATUSBAR_TIMEOUT_MS);
+
+		/**
+		 * Clear message from status bar.
+		 **/
+		void clearMessage();
+	private:
+		///Status text
+		QLabel *text;
+		///Status icon
+		QLabel *icon;
+		///Timer for clearing the status bar
+		QTimer *timer;
+
+};
 
 /**
  * Mainwindow container widget opened when starting digcross.
@@ -18,6 +63,7 @@ class MainWindow : public QWidget {
 		DaemonClient *transactionDaemon;
 		///Card reader
 		CardReader *cardReader;
+		StatusBar *statusBar;
 	private slots:
 		/**
 		 * Start a transaction. Calculates amount to transact from shoppingList.
@@ -34,14 +80,6 @@ class MainWindow : public QWidget {
 		 * \param status Transaction status
 		 **/
 		void receiveTransactionFeedback(QString cardNumber, float newBalance, DaemonClient::TransactionStatus status);
-
-		/**
-		 * Show message in MainWindow. Displays appropriate icons based on the success variable.
-		 *
-		 * \param success Whether action calling this function was a success or not
-		 * \param message Message to display
-		 **/
-		void showMessage(bool success, QString message);
 
 		/**
 		 * Add a couple of test items to the shopping list.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -21,6 +21,7 @@ class MainWindow : public QWidget {
 		DaemonClient *transactionDaemon;
 		///Card reader
 		CardReader *cardReader;
+		///Status bar for displaying messages to user
 		StatusBar *statusBar;
 	private slots:
 		/**
@@ -43,13 +44,21 @@ class MainWindow : public QWidget {
 		 * Add a couple of test items to the shopping list.
 		 **/
 		void addTestItems();
+
+		/**
+		 * For receiving signal from shoppingList that the total price has changed. Informs the user through the status bar.
+		 **/
+		void updateDisplayPrice();
 };
 
 ///Default timeout of status bar messages
 const int STATUSBAR_TIMEOUT_MS = 5000;
 
 /**
- * Status bar. More or less like QStatusBar, but with an icon on the right side.
+ * Status bar, displays messages to the user with an optional icon on the left side.
+ * Can display temporary messages which revert to a permanent message after a given time.
+ *
+ * (Similar to QStatusBar, but with customized features.)
  **/
 class StatusBar : public QWidget {
 	Q_OBJECT
@@ -66,24 +75,40 @@ class StatusBar : public QWidget {
 		};
 	public slots:
 		/**
-		 * Display message on statusbar together with an optional icon.
+		 * Display temporary message on statusbar together with an optional icon.
+		 * If a permanent message has been set, the status bar will revert to
+		 * the permanent message after the timeout (otherwise set the status bar empty).
 		 *
 		 * \param message Message to display
 		 * \param icon Icon to display
 		 * \param timeout Timeout value of message
 		 **/
-		void showMessage(QString message, StatusIcon icon = NO_ICON, int timeout = STATUSBAR_TIMEOUT_MS);
+		void setTemporaryMessage(QString message, StatusIcon icon = NO_ICON, int timeout = STATUSBAR_TIMEOUT_MS);
 
 		/**
-		 * Clear message from status bar.
+		 * Set a permanent message on the status bar. Any temporary messages will immediately
+		 * be cleared. Temporary messages will overwrite the permanent message, but the status bar
+		 * reverts to the permanent message after the timeout.
 		 **/
-		void clearMessage();
+		void setPermanentMessage(QString message);
+
+		/**
+		 * Clear temporary message from status bar, revert to permanent message (or empty status bar).
+		 **/
+		void clearTemporaryMessage();
+
+		/**
+		 * Clear permanent message from status bar, but not temporary messages that are still being displayed.
+		 **/
+		void clearPermanentMessage();
 	private:
+		///Message the status bar will revert to when the temporary message is cleared
+		QString permanentMessage;
 		///Status text
 		QLabel *text;
 		///Status icon
 		QLabel *icon;
-		///Timer for clearing the status bar
+		///Timer for clearing temporary messages from the status bar
 		QTimer *timer;
 
 };

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -178,7 +178,7 @@ ShoppingListItemDelegate::ShoppingListItemDelegate(QObject *parent) : QStyledIte
 {
 }
 
-void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &inputOption, const QModelIndex &index) const Q_DECL_OVERRIDE
+void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &inputOption, const QModelIndex &index) const
 {
 	QStyleOptionViewItem option = inputOption;
 	option.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
@@ -221,18 +221,14 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	//use custom delegate for displaying each item
 	listView->setItemDelegate(new ShoppingListItemDelegate);
 
-	QPushButton *wipeButton = new QPushButton(qApp->style()->standardIcon(QStyle::SP_DialogResetButton), tr("Wipe list"));
-
 	//layout
 	QGridLayout *layout = new QGridLayout(this);
 	int row = 0;
 	int col = 0;
 
 	layout->addWidget(listView, row, col, 1, 2);
-	layout->addWidget(wipeButton, ++row, ++col, Qt::AlignRight);
 
 	//connections
-	connect(wipeButton, SIGNAL(clicked()), list, SLOT(wipeList()));
 	connect(listView, SIGNAL(clicked(const QModelIndex &)), SLOT(deleteShoppingListRow(const QModelIndex &)));
 }
 

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -221,9 +221,7 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	//use custom delegate for displaying each item
 	listView->setItemDelegate(new ShoppingListItemDelegate);
 
-	//buttons and labellzzz
 	QPushButton *wipeButton = new QPushButton(qApp->style()->standardIcon(QStyle::SP_DialogResetButton), tr("Wipe list"));
-	currentTotalPrice = new QLabel;
 
 	//layout
 	QGridLayout *layout = new QGridLayout(this);
@@ -231,21 +229,11 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	int col = 0;
 
 	layout->addWidget(listView, row, col, 1, 2);
-	layout->addWidget(currentTotalPrice, ++row, col, Qt::AlignLeft);
-	layout->addWidget(wipeButton, row, ++col, Qt::AlignRight);
-
-	updateDisplayPrice();
+	layout->addWidget(wipeButton, ++row, ++col, Qt::AlignRight);
 
 	//connections
-	connect(list, SIGNAL(totalPriceChanged()), SLOT(updateDisplayPrice()));
 	connect(wipeButton, SIGNAL(clicked()), list, SLOT(wipeList()));
 	connect(listView, SIGNAL(clicked(const QModelIndex &)), SLOT(deleteShoppingListRow(const QModelIndex &)));
-}
-
-void ShoppingListWidget::updateDisplayPrice()
-{
-	double currPrice = shoppingList->getTotalPrice();
-	currentTotalPrice->setText("Sum: " + QString::number(currPrice) + " kr");
 }
 
 void ShoppingListWidget::deleteShoppingListRow(const QModelIndex &index)

--- a/src/shoppinglist.cpp
+++ b/src/shoppinglist.cpp
@@ -142,11 +142,11 @@ QVariant ShoppingList::data(const QModelIndex &index, int role) const
 
 Qt::ItemFlags ShoppingList::flags(const QModelIndex &index) const
 {
+	Qt::ItemFlags retFlags = Qt::ItemIsEnabled;
 	if (index.column() == ITEM_AMOUNT_COL) {
-		return Qt::ItemIsEnabled | Qt::ItemIsEditable;
-	} else {
-		return Qt::NoItemFlags;
+		retFlags |= Qt::ItemIsEditable;
 	}
+	return retFlags;
 }
 
 /**
@@ -181,23 +181,22 @@ ShoppingListItemDelegate::ShoppingListItemDelegate(QObject *parent) : QStyledIte
 void ShoppingListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &inputOption, const QModelIndex &index) const Q_DECL_OVERRIDE
 {
 	QStyleOptionViewItem option = inputOption;
+	option.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
 	if (index.column() == ITEM_AMOUNT_COL) {
 		//draw amount + "x"
 		option.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
 		painter->drawText(option.rect, option.displayAlignment, index.data().toString() + " x ");
 	} else if (index.column() == ITEM_PRICE_COL) {
 		//draw price + "kr"
-		option.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
 		painter->drawText(option.rect, option.displayAlignment, "(" + index.data().toString() + " kr)");
 	} else if (index.column() == ITEM_NAME_COL) {
-		option.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
 		painter->drawText(option.rect, option.displayAlignment, index.data().toString());
 	} else if (index.column() == ITEM_DELETEBUTTON_COL) {
 		//draw delete button in its assigned column
 		QStyleOptionButton buttonOptions;
 		buttonOptions.features = QStyleOptionButton::Flat;
 		buttonOptions.rect = inputOption.rect;
-		buttonOptions.state = QStyle::State_Enabled;
+		buttonOptions.state = inputOption.state;
 		buttonOptions.icon = qApp->style()->standardIcon(QStyle::SP_DialogCancelButton);
 		buttonOptions.iconSize = inputOption.rect.size();
 		qApp->style()->drawControl(QStyle::CE_PushButton, &buttonOptions, painter);
@@ -213,7 +212,8 @@ ShoppingListWidget::ShoppingListWidget(ShoppingList *list, QWidget *parent) : QW
 	listView->verticalHeader()->hide();
 	listView->horizontalHeader()->hide();
 	listView->setAlternatingRowColors(true);
-	listView->setGridStyle(Qt::NoPen);
+	listView->setShowGrid(false);
+	listView->setEditTriggers(QAbstractItemView::DoubleClicked);
 	listView->setModel(list);
 	listView->horizontalHeader()->setSectionResizeMode(ITEM_PRICE_COL, QHeaderView::Stretch);
 	listView->resizeColumnToContents(ITEM_DELETEBUTTON_COL);

--- a/src/shoppinglist.h
+++ b/src/shoppinglist.h
@@ -189,14 +189,7 @@ class ShoppingListWidget : public QWidget {
 	private:
 		///Convenience pointer to the canonical shopping list
 		ShoppingList *shoppingList;
-		///Label for displaying the current total price of items in shopping list
-		QLabel *currentTotalPrice;
 	private slots:
-		/**
-		 * Signal that price displayed in currentTotalPrice should be recalculated from shoppingList.
-		 **/
-		void updateDisplayPrice();
-
 		/**
 		 * Delete shopping list item corresponding to the specified index, given that index.column() corresponds to ITEM_DELETEBUTTON_ROW (user clicked on the cell corresponding to the delete button).
 		 *

--- a/tests/cardreader-t.cpp
+++ b/tests/cardreader-t.cpp
@@ -27,7 +27,7 @@ void CardReaderTest::simulateKeyboardInput()
 	QSignalSpy spy(&cardReader, SIGNAL(newCardNumber(QString)));
 	QVERIFY(spy.isValid());
 
-	int keyTypingTime = CARDREADER_TIME_LIMIT_MS*1.0/((TEST_CARDNUMBER.size())*1.0);
+	int keyTypingTime = 50;
 	QTest::keyClicks(&widget, TEST_CARDNUMBER, Qt::NoModifier, keyTypingTime);
 	QTest::keyClick(&widget, Qt::Key_Return);
 

--- a/tests/daemon_client-t.cpp
+++ b/tests/daemon_client-t.cpp
@@ -6,7 +6,7 @@
 #include <QtDBus/QtDBus>
 #include "daemon_common.h"
 
-const int SIGNAL_TIMEOUT = 1000;
+const int SIGNAL_TIMEOUT = 2000;
 
 void DaemonClientTest::dbusServiceAvailable()
 {
@@ -32,18 +32,18 @@ void DaemonClientTest::sendTransactionRequestToDaemonAndWaitForFeedback()
 {
 	DaemonClient client;
 
-	QSignalSpy transactionSpy(&client, SIGNAL(transactionFeedback(QString, float, TransactionStatus)));
+	QSignalSpy transactionSpy(&client, SIGNAL(transactionFeedback(QString, float, DaemonClient::TransactionStatus)));
 	QVERIFY(transactionSpy.isValid());
 
 	//send dummy card number
 	QString cardNumber = "test_cardnumber_1234";
 	client.processTransaction(cardNumber, 0);
 
-	//verify that we receive the same card number back in the transaction feedback
+	//verify that we receive something back
 	QVERIFY2(transactionSpy.wait(SIGNAL_TIMEOUT), "DBus call timed out, digcrossd service likely not running.");
 	QCOMPARE(transactionSpy.count(), 1);
 	QList<QVariant> arguments = transactionSpy.takeFirst();
-	QCOMPARE(arguments.at(0).toString(), cardNumber);
+	QCOMPARE(arguments.size(), 3);
 }
 
 QTEST_MAIN(DaemonClientTest)


### PR DESCRIPTION
Solves issue #9 by adding handling of card number, shopping list and transaction feedback.

If CARDREADER_TIME_LIMIT in src/cardreader.h is increased to e.g. 10000, card numbers can be input manually by typing out numbers/letters and pressing return. '1234' corresponds to a card number which is accepted by the transaction daemon.

Screenshots:

![2016-10-22-215720_1366x768_scrot](https://cloud.githubusercontent.com/assets/1886244/19622147/531d8702-98a3-11e6-87b2-dc3dc01d6358.png)
![2016-10-22-215726_1366x768_scrot](https://cloud.githubusercontent.com/assets/1886244/19622148/531f56cc-98a3-11e6-987a-e7ab1e690f87.png)
![2016-10-22-215815_1366x768_scrot](https://cloud.githubusercontent.com/assets/1886244/19622152/533b2e06-98a3-11e6-8bff-afe8e86382ef.png)
Shopping list is not wiped when the transaction is unsuccessful, and time-limited message indicates the point of failure. (Reverts back to "Swipe a card to ..." after 5 seconds)
![2016-10-22-215754_1366x768_scrot](https://cloud.githubusercontent.com/assets/1886244/19622150/532cca50-98a3-11e6-90c7-e86117520b9e.png)
Shopping list is wiped on successful transaction, and a time-limited message indicating transaction success is displayed in the status bar. 
![2016-10-22-215800_1366x768_scrot](https://cloud.githubusercontent.com/assets/1886244/19622151/532fbddc-98a3-11e6-9d68-1cb5dddbd744.png)
After five seconds, the status bar displays details of the last transaction until items are added to shopping list again.

Should error messages force the user to click a button to continue, or is it enough to display errors for five seconds in the status line?
