### PR TITLE
Issue17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(digcrossd daemon/main.cpp daemon/daemon.cpp)
 target_link_libraries(digcrossd Qt5::DBus Qt5::Widgets)
 
 #daemon config
-set(DIGCROSSD_USER $ENV{USER}) #FIXME: Set a different username (e.g. digcrossd)
+set(DIGCROSSD_USER "digcrossd")
 configure_file(daemon-config/org.digcross.daemonconnection.service.in org.digcross.daemonconnection.service @ONLY)
 configure_file(daemon-config/org.digcross.daemonconnection.conf.in org.digcross.daemonconnection.conf @ONLY)
 
@@ -24,6 +24,10 @@ configure_file(daemon-config/org.digcross.daemonconnection.conf.in org.digcross.
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.digcross.daemonconnection.service DESTINATION /usr/share/dbus-1/system-services)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.digcross.daemonconnection.conf DESTINATION /etc/dbus-1/system.d)
 install(TARGETS digcrossd DESTINATION bin)
+
+#daemon user creation
+configure_file(${CMAKE_SOURCE_DIR}/CreateDigcrossdUser.cmake.in ${CMAKE_BINARY_DIR}/CreateDigcrossdUser.cmake @ONLY)
+install(SCRIPT "${CMAKE_BINARY_DIR}/CreateDigcrossdUser.cmake")
 
 #tests
 if (WITH_TESTING)

--- a/CreateDigcrossdUser.cmake.in
+++ b/CreateDigcrossdUser.cmake.in
@@ -1,0 +1,2 @@
+set(DIGCROSSD_USER @DIGCROSSD_USER@)
+execute_process(COMMAND adduser --system ${DIGCROSSD_USER})

--- a/daemon/daemon.cpp
+++ b/daemon/daemon.cpp
@@ -3,6 +3,7 @@
 #include <QtDBus/QtDBus>
 #include <iostream>
 #include "daemon_common.h"
+#include <syslog.h>
 
 void Daemon::processTransaction(QString card_number, QString amount, const QDBusMessage &msg)
 {
@@ -23,16 +24,23 @@ void Daemon::processTransaction(QString card_number, QString amount, const QDBus
 	QDBusConnection::systemBus().send(reply);
 }
 
+void write_to_syslog(const char *message)
+{
+	openlog("digcrossd", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL0);
+	syslog(LOG_ERR, message);
+	closelog();
+}
+
 Daemon::Daemon(QObject *parent) : QObject(parent)
 {
 	//check for dbus errors
 	if (!QDBusConnection::systemBus().isConnected()) {
-		fprintf(stderr, "Cannot connect to the D-Bus system bus.\n");
+		write_to_syslog("Cannot connect to the D-Bus system bus.");
 		exit(1);
 	}
 
 	if (!QDBusConnection::systemBus().registerService(DBUS_SERVICE_NAME)) {
-		fprintf(stderr, "%s\n",	qPrintable(QDBusConnection::systemBus().lastError().message()));
+		write_to_syslog(qPrintable(QDBusConnection::systemBus().lastError().message()));
 		exit(1);
 	}
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -17,10 +17,12 @@ On the daemon's end, transactions are received using `Daemon::processTransaction
 Configuration files
 -------------------
 
-It is assumed that `digcrossd` will eventually be run by a separate user from the user running the GUI application. The DBus calls are therefore sent through the system bus, as the session bus is per-user. This necessitates special DBus policies for the user running `digcrossd`, which has been specified in `daemon-config/org.digcross.daemonconnection.conf.in`.
+`digcrossd` is run by a separate user from the user running the GUI application. The DBus calls are therefore sent through the system bus, as the session bus is per-user. This necessitates special DBus policies for the user running `digcrossd`, which has been specified in `daemon-config/org.digcross.daemonconnection.conf.in`.
 
 In addition, for convenience, `digcrossd` is activated as a DBus service when needed by the GUI application. This means that `digcrossd` won't have to be started in advance or during boot, but will start when needed, automagically. This is specified in `daemon-config/org.digcross.daemonconnection.service.in`.
 
-Both configuration files contain references to the user running the `digcrossd` application. The username is specified in the variable `DIGCROSSD_USER` in `CMakeLists.txt`, currently set to be the user compiling the application.
+Both configuration files contain references to the user running the `digcrossd` application. The username is specified in the variable `DIGCROSSD_USER` in `CMakeLists.txt`.
 
 Both configuration files need to be installed to system-wide DBus configuration directories. This is specified by install rules in `CMakeLists.txt`.
+
+The `digcrossd` user is automatically created by CMake using `CreateDigcrossdUser.cmake` when `make install` is run.


### PR DESCRIPTION
Solves issue #17 by adding a new (system) user `digcrossd` that is set up to run the digcross daemon.

It is impossible to log in as this user.

Note that dbus probably has to be restarted for the policy changes to take effect. 
